### PR TITLE
feat(diagnostics): Check and report invalid type expressions in value positions

### DIFF
--- a/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/common/generated/public_api.txt
@@ -2784,6 +2784,22 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedExperime
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedExperimentalSolidity::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::syntax::UnsupportedExperimentalSolidity::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub mod slang_solidity_v2_common::diagnostics::kinds::type_system
+pub enum slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::BuiltIn
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::Super
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::TypeOrModule
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::UncalledNew
+impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+impl core::cmp::PartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::eq(&self, &slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind) -> bool
+impl core::fmt::Debug for slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+impl core::marker::StructuralPartialEq for slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+impl serde_core::ser::Serialize for slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
+pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 pub enum slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthFractional(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthFractional)
 pub slang_solidity_v2_common::diagnostics::kinds::type_system::TypeSystemDiagnosticKind::ArrayLengthNegative(slang_solidity_v2_common::diagnostics::kinds::type_system::ArrayLengthNegative)
@@ -2995,6 +3011,7 @@ pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithm
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::message(&self) -> alloc::string::String
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ConstantArithmeticError::severity(&self) -> slang_solidity_v2_common::diagnostics::DiagnosticSeverity
 pub struct slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotAValue
+pub slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotAValue::kind: slang_solidity_v2_common::diagnostics::kinds::type_system::NotAValueKind
 impl core::clone::Clone for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotAValue
 pub fn slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotAValue::clone(&self) -> slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotAValue
 impl core::cmp::Eq for slang_solidity_v2_common::diagnostics::kinds::type_system::ExpressionNotAValue

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/expression_not_a_value.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/expression_not_a_value.rs
@@ -3,12 +3,28 @@ use serde::Serialize;
 use crate::diagnostics::extensions::DiagnosticExtensions;
 use crate::diagnostics::severity::DiagnosticSeverity;
 
-/// Diagnostic emitted when an expression that names a type (eg. `uint`, or an
-/// enum or contract name), a module (an import alias) or a function
-/// declaration reached through a contract type name (eg. `C.f`) is used where
-/// a value is required, eg. as a branch of a conditional: `c ? E : E.A`.
+/// What an expression names, where a value was required.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub enum NotAValueKind {
+    /// A built-in: a namespace such as `abi`, or a built-in function such as
+    /// `keccak256`.
+    BuiltIn,
+    /// The `super` base-contract reference.
+    Super,
+    /// A type reference.
+    TypeOrModule,
+    /// A `new` contract creation that is never called.
+    UncalledNew,
+}
+
+/// Diagnostic emitted when an expression is used where a value is required but
+/// it names something else. A statement is not such a position: naming a
+/// built-in or `super` there is inert and accepted.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct ExpressionNotAValue;
+pub struct ExpressionNotAValue {
+    /// What the expression names instead of a value.
+    pub kind: NotAValueKind,
+}
 
 impl DiagnosticExtensions for ExpressionNotAValue {
     fn severity(&self) -> DiagnosticSeverity {
@@ -20,6 +36,12 @@ impl DiagnosticExtensions for ExpressionNotAValue {
     }
 
     fn message(&self) -> String {
-        "This expression denotes a type or declaration, not a value.".to_owned()
+        let named = match self.kind {
+            NotAValueKind::BuiltIn => "This built-in",
+            NotAValueKind::Super => "'super'",
+            NotAValueKind::TypeOrModule => "This expression denoting a type or module",
+            NotAValueKind::UncalledNew => "An uncalled 'new' expression",
+        };
+        format!("{named} cannot be used as a value.")
     }
 }

--- a/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/common/src/diagnostics/kinds/type_system/mod.rs
@@ -26,7 +26,7 @@ pub use array_length_too_large::ArrayLengthTooLarge;
 pub use array_length_zero::ArrayLengthZero;
 pub use cannot_call_via_contract_type_name::CannotCallViaContractTypeName;
 pub use constant_arithmetic_error::ConstantArithmeticError;
-pub use expression_not_a_value::ExpressionNotAValue;
+pub use expression_not_a_value::{ExpressionNotAValue, NotAValueKind};
 pub use expression_not_callable::ExpressionNotCallable;
 pub use fallback_function_mutability::FallbackFunctionMutability;
 pub use fallback_function_signature::FallbackFunctionSignature;
@@ -91,7 +91,8 @@ define_diagnostic_kind! {
         CannotCallViaContractTypeName(CannotCallViaContractTypeName),
         /// The callee of a call is not callable.
         ExpressionNotCallable(ExpressionNotCallable),
-        /// An expression naming a type or declaration is used as a value.
+        /// An expression in a position that requires a value names a built-in,
+        /// `super`, or an uncalled `new` instead. Its `kind` says which.
         ExpressionNotAValue(ExpressionNotAValue),
         /// A partially applied function is used as a value rather than called.
         PartiallyAppliedFunctionUsedAsValue(PartiallyAppliedFunctionUsedAsValue),

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -495,6 +495,11 @@ impl<'a> BuiltInsResolver<'a> {
         built_in: &InternalBuiltIn,
         argument_types: Option<&[TypeId]>,
     ) -> Result<TypeId, BuiltInCallError> {
+        // If any of the arguments failed to type, we don't attempt to resolve
+        // the built-in call.
+        let Some(argument_types) = argument_types else {
+            return Err(BuiltInCallError::UnresolvedDependency);
+        };
         let type_id = match built_in {
             InternalBuiltIn::AbiDecode => self.type_of_abi_decode(argument_types)?,
             InternalBuiltIn::AbiEncode => self.types.bytes_memory(),
@@ -511,9 +516,8 @@ impl<'a> BuiltInsResolver<'a> {
             InternalBuiltIn::AddressTransfer => self.types.void(),
             InternalBuiltIn::ArrayPush(type_id) => {
                 // `push()` yields a reference to the new element, `push(v)`
-                // yields nothing. A missing type list means there was an
-                // argument, so it is the latter.
-                if argument_types.is_some_and(<[TypeId]>::is_empty) {
+                // yields nothing.
+                if argument_types.is_empty() {
                     *type_id
                 } else {
                     self.types.void()
@@ -568,22 +572,17 @@ impl<'a> BuiltInsResolver<'a> {
 
     fn type_of_abi_decode(
         &mut self,
-        argument_types: Option<&[TypeId]>,
+        argument_types: &[TypeId],
     ) -> Result<TypeId, BuiltInCallError> {
-        let Some(argument_types) = argument_types else {
-            return Err(BuiltInCallError::UnresolvedDependency);
-        };
         // TODO(validation): report an error when `abi.decode` is not given
         // exactly two arguments.
-        if argument_types.len() != 2 {
+        let [_, type_id] = argument_types else {
             return Err(BuiltInCallError::NotReportedYet);
-        }
-        // The second argument's own type failed to resolve.
-        let type_id = argument_types[1];
+        };
 
         // `abi.decode(data, (T))`: a single-element tuple collapses to the
         // meta-type of `T`, which decodes to `T` itself.
-        if let Some(decoded) = self.type_denoted_by_meta_type(type_id) {
+        if let Some(decoded) = self.type_denoted_by_meta_type(*type_id) {
             return Ok(decoded);
         }
 
@@ -591,7 +590,7 @@ impl<'a> BuiltInsResolver<'a> {
         // the tuple of the types they denote. Note a *nested* tuple element is
         // not a type name and does not decode (matching solc, which rejects
         // eg. `abi.decode(data, (uint, (bool, bool)))`).
-        if let Type::Tuple(TupleType { types }) = self.types.get_type_by_id(type_id) {
+        if let Type::Tuple(TupleType { types }) = self.types.get_type_by_id(*type_id) {
             let element_ids = types.clone();
             let mut decoded = Vec::with_capacity(element_ids.len());
             for element_id in element_ids {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -493,10 +493,10 @@ impl<'a> BuiltInsResolver<'a> {
     pub(crate) fn type_of_function_call(
         &mut self,
         built_in: &InternalBuiltIn,
-        argument_typings: &[Typing],
+        argument_types: Option<&[TypeId]>,
     ) -> Result<TypeId, BuiltInCallError> {
         let type_id = match built_in {
-            InternalBuiltIn::AbiDecode => self.type_of_abi_decode(argument_typings)?,
+            InternalBuiltIn::AbiDecode => self.type_of_abi_decode(argument_types)?,
             InternalBuiltIn::AbiEncode => self.types.bytes_memory(),
             InternalBuiltIn::AbiEncodeCall => self.types.bytes_memory(),
             InternalBuiltIn::AbiEncodePacked => self.types.bytes_memory(),
@@ -510,7 +510,10 @@ impl<'a> BuiltInsResolver<'a> {
             InternalBuiltIn::AddressStaticcall => self.types.boolean_bytes_tuple(),
             InternalBuiltIn::AddressTransfer => self.types.void(),
             InternalBuiltIn::ArrayPush(type_id) => {
-                if argument_typings.is_empty() {
+                // `push()` yields a reference to the new element, `push(v)`
+                // yields nothing. A missing type list means there was an
+                // argument, so it is the latter.
+                if argument_types.is_some_and(<[TypeId]>::is_empty) {
                     *type_id
                 } else {
                     self.types.void()
@@ -565,21 +568,22 @@ impl<'a> BuiltInsResolver<'a> {
 
     fn type_of_abi_decode(
         &mut self,
-        argument_typings: &[Typing],
+        argument_types: Option<&[TypeId]>,
     ) -> Result<TypeId, BuiltInCallError> {
+        let Some(argument_types) = argument_types else {
+            return Err(BuiltInCallError::UnresolvedDependency);
+        };
         // TODO(validation): report an error when `abi.decode` is not given
         // exactly two arguments.
-        if argument_typings.len() != 2 {
+        if argument_types.len() != 2 {
             return Err(BuiltInCallError::NotReportedYet);
         }
         // The second argument's own type failed to resolve.
-        let Typing::Resolved(type_id) = &argument_typings[1] else {
-            return Err(BuiltInCallError::UnresolvedDependency);
-        };
+        let type_id = argument_types[1];
 
         // `abi.decode(data, (T))`: a single-element tuple collapses to the
         // meta-type of `T`, which decodes to `T` itself.
-        if let Some(decoded) = self.type_denoted_by_meta_type(*type_id) {
+        if let Some(decoded) = self.type_denoted_by_meta_type(type_id) {
             return Ok(decoded);
         }
 
@@ -587,7 +591,7 @@ impl<'a> BuiltInsResolver<'a> {
         // the tuple of the types they denote. Note a *nested* tuple element is
         // not a type name and does not decode (matching solc, which rejects
         // eg. `abi.decode(data, (uint, (bool, bool)))`).
-        if let Type::Tuple(TupleType { types }) = self.types.get_type_by_id(*type_id) {
+        if let Type::Tuple(TupleType { types }) = self.types.get_type_by_id(type_id) {
             let element_ids = types.clone();
             let mut decoded = Vec::with_capacity(element_ids.len());
             for element_id in element_ids {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/disambiguation.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/disambiguation.rs
@@ -220,7 +220,7 @@ impl Pass<'_> {
     pub(super) fn lookup_function_matching_named_arguments(
         &self,
         type_ids: &[TypeId],
-        argument_types: &[(String, TypeId)],
+        argument_types: &[(&str, TypeId)],
         receiver_type_id: Option<TypeId>,
     ) -> OverloadMatch<TypeId> {
         self.lookup_function_matching_arguments(
@@ -241,7 +241,7 @@ impl Pass<'_> {
     fn parameters_match_named_arguments(
         &self,
         parameters: &[ParameterDefinition],
-        argument_types: &[(String, TypeId)],
+        argument_types: &[(&str, TypeId)],
         external_call: bool,
     ) -> bool {
         argument_types.iter().all(|(argument_name, argument_type)| {
@@ -296,7 +296,7 @@ impl Pass<'_> {
     pub(super) fn lookup_event_matching_named_arguments(
         &self,
         definition_ids: &[NodeId],
-        argument_types: &[(String, TypeId)],
+        argument_types: &[(&str, TypeId)],
     ) -> OverloadMatch<NodeId> {
         OverloadMatch::from_matches(definition_ids.iter().copied().filter(|definition_id| {
             let Some(parameters) = self.get_event_definition_parameters(*definition_id) else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/disambiguation.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/disambiguation.rs
@@ -1,7 +1,7 @@
 use slang_solidity_v2_common::nodes::NodeId;
 
 use super::Pass;
-use crate::binder::{Definition, ParameterDefinition, Scope, Typing};
+use crate::binder::{Definition, ParameterDefinition, Scope};
 use crate::types::{FunctionType, Type, TypeId, UserMetaType};
 
 /// The outcome of selecting one overload out of a set of candidates.
@@ -165,17 +165,17 @@ impl Pass<'_> {
     pub(super) fn lookup_function_matching_positional_arguments(
         &self,
         type_ids: &[TypeId],
-        argument_typings: &[Typing],
+        argument_types: &[TypeId],
         receiver_type_id: Option<TypeId>,
     ) -> OverloadMatch<TypeId> {
         self.lookup_function_matching_arguments(
             type_ids,
-            argument_typings.len(),
+            argument_types.len(),
             receiver_type_id,
             |parameters, external_call| {
                 self.parameters_match_positional_arguments(
                     parameters,
-                    argument_typings,
+                    argument_types,
                     external_call,
                 )
             },
@@ -185,50 +185,47 @@ impl Pass<'_> {
     fn parameters_match_positional_arguments(
         &self,
         parameters: &[ParameterDefinition],
-        argument_typings: &[Typing],
+        argument_types: &[TypeId],
         external_call: bool,
     ) -> bool {
         parameters
             .iter()
-            .zip(argument_typings)
-            .all(|(parameter, argument_typing)| {
+            .zip(argument_types)
+            .all(|(parameter, argument_type)| {
                 parameter.type_id.is_some_and(|type_id| {
-                    self.parameter_type_matches_argument_typing(
+                    self.parameter_type_matches_argument_type(
                         type_id,
-                        argument_typing,
+                        *argument_type,
                         external_call,
                     )
                 })
             })
     }
 
-    fn parameter_type_matches_argument_typing(
+    fn parameter_type_matches_argument_type(
         &self,
         parameter_type: TypeId,
-        argument_typing: &Typing,
+        argument_type: TypeId,
         external_call: bool,
     ) -> bool {
-        let Some(type_id) = argument_typing.as_type_id() else {
-            return false;
-        };
         if external_call {
             self.types
-                .implicitly_convertible_to_for_external_call(type_id, parameter_type)
+                .implicitly_convertible_to_for_external_call(argument_type, parameter_type)
         } else {
             self.types
-                .implicitly_convertible_to(type_id, parameter_type)
+                .implicitly_convertible_to(argument_type, parameter_type)
         }
     }
 
     pub(super) fn lookup_function_matching_named_arguments(
         &self,
         type_ids: &[TypeId],
-        argument_typings: &[(String, Typing)],
+        argument_types: &[(String, TypeId)],
         receiver_type_id: Option<TypeId>,
     ) -> OverloadMatch<TypeId> {
         self.lookup_function_matching_arguments(
             type_ids,
-            argument_typings.len(),
+            argument_types.len(),
             receiver_type_id,
             |parameters, external_call| {
                 if parameters.iter().any(|parameter| parameter.name.is_none()) {
@@ -236,7 +233,7 @@ impl Pass<'_> {
                     // for matching named arguments
                     return false;
                 }
-                self.parameters_match_named_arguments(parameters, argument_typings, external_call)
+                self.parameters_match_named_arguments(parameters, argument_types, external_call)
             },
         )
     }
@@ -244,28 +241,22 @@ impl Pass<'_> {
     fn parameters_match_named_arguments(
         &self,
         parameters: &[ParameterDefinition],
-        argument_typings: &[(String, Typing)],
+        argument_types: &[(String, TypeId)],
         external_call: bool,
     ) -> bool {
-        argument_typings
-            .iter()
-            .all(|(argument_name, argument_typing)| {
-                let Some(parameter) = parameters.iter().find(|parameter| {
-                    parameter
-                        .name
-                        .as_ref()
-                        .is_some_and(|name| name == argument_name)
-                }) else {
-                    return false;
-                };
-                parameter.type_id.is_some_and(|type_id| {
-                    self.parameter_type_matches_argument_typing(
-                        type_id,
-                        argument_typing,
-                        external_call,
-                    )
-                })
+        argument_types.iter().all(|(argument_name, argument_type)| {
+            let Some(parameter) = parameters.iter().find(|parameter| {
+                parameter
+                    .name
+                    .as_ref()
+                    .is_some_and(|name| name == argument_name)
+            }) else {
+                return false;
+            };
+            parameter.type_id.is_some_and(|type_id| {
+                self.parameter_type_matches_argument_type(type_id, *argument_type, external_call)
             })
+        })
     }
 
     fn get_event_definition_parameters(
@@ -290,22 +281,22 @@ impl Pass<'_> {
     pub(super) fn lookup_event_matching_positional_arguments(
         &self,
         definition_ids: &[NodeId],
-        argument_typings: &[Typing],
+        argument_types: &[TypeId],
     ) -> OverloadMatch<NodeId> {
         OverloadMatch::from_matches(definition_ids.iter().copied().filter(|definition_id| {
             let Some(parameters) = self.get_event_definition_parameters(*definition_id) else {
                 return false;
             };
             // argument count matches, check that all types are implicitly convertible
-            parameters.len() == argument_typings.len()
-                && self.parameters_match_positional_arguments(parameters, argument_typings, false)
+            parameters.len() == argument_types.len()
+                && self.parameters_match_positional_arguments(parameters, argument_types, false)
         }))
     }
 
     pub(super) fn lookup_event_matching_named_arguments(
         &self,
         definition_ids: &[NodeId],
-        argument_typings: &[(String, Typing)],
+        argument_types: &[(String, TypeId)],
     ) -> OverloadMatch<NodeId> {
         OverloadMatch::from_matches(definition_ids.iter().copied().filter(|definition_id| {
             let Some(parameters) = self.get_event_definition_parameters(*definition_id) else {
@@ -314,8 +305,8 @@ impl Pass<'_> {
             // cannot match if any parameter is unnamed
             parameters.iter().all(|parameter| parameter.name.is_some())
                 // argument count matches, check that all types are implicitly convertible
-                && parameters.len() == argument_typings.len()
-                && self.parameters_match_named_arguments(parameters, argument_typings, false)
+                && parameters.len() == argument_types.len()
+                && self.parameters_match_named_arguments(parameters, argument_types, false)
         }))
     }
 }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -4,7 +4,8 @@ use slang_solidity_v2_common::diagnostics::kinds::resolution::{
 };
 use slang_solidity_v2_common::diagnostics::kinds::type_system::{
     CannotCallViaContractTypeName, ExpressionNotAValue, ExpressionNotCallable,
-    IncompatibleConditionalBranches, LiteralTooLarge, PartiallyAppliedFunctionUsedAsValue,
+    IncompatibleConditionalBranches, LiteralTooLarge, NotAValueKind,
+    PartiallyAppliedFunctionUsedAsValue,
 };
 use slang_solidity_v2_common::nodes::NodeId;
 use slang_solidity_v2_ir::ir;
@@ -72,13 +73,28 @@ impl Pass<'_> {
         node: &ir::Expression,
     ) -> Option<TypeId> {
         match self.check_typing_of_expression(node) {
-            Typing::BuiltIn(_) | Typing::NewExpression(_) | Typing::Super => {
-                // TODO(validation): report that the expression names a built-in,
-                // a base contract or a contract creation rather than a value.
+            Typing::BuiltIn(_) => {
+                self.report_expression_not_a_value(node, NotAValueKind::BuiltIn);
+                None
+            }
+            Typing::Super => {
+                self.report_expression_not_a_value(node, NotAValueKind::Super);
+                None
+            }
+            Typing::NewExpression(_) => {
+                self.report_expression_not_a_value(node, NotAValueKind::UncalledNew);
                 None
             }
             typing => typing.as_type_id(),
         }
+    }
+
+    /// Reports `node` as naming something other than a value. Kept out of line
+    /// for the same reason as [`Self::report_ambiguous_reference`].
+    #[cold]
+    #[inline(never)]
+    fn report_expression_not_a_value(&mut self, node: &ir::Expression, kind: NotAValueKind) {
+        self.push_diagnostic(node, ExpressionNotAValue { kind });
     }
 
     /// Narrows an overload lookup for a call down to the selected candidate,
@@ -204,7 +220,12 @@ impl Pass<'_> {
         match self.types.compute_mobile_type(type_id) {
             Ok(mobile) => Some(mobile),
             Err(NoMobileType::NotAValue) => {
-                self.push_diagnostic(branch, ExpressionNotAValue);
+                self.push_diagnostic(
+                    branch,
+                    ExpressionNotAValue {
+                        kind: NotAValueKind::TypeOrModule,
+                    },
+                );
                 None
             }
             Err(NoMobileType::PartiallyAppliedFunction) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -403,6 +403,9 @@ impl Pass<'_> {
     ) -> Option<TypeId> {
         let mut item_type_ids: Vec<TypeId> = Vec::with_capacity(array.items.len());
         let mut all_typed = true;
+        // Every element is checked before the determining the array type, so
+        // one that has no type does not stop the rest from being checked (and
+        // reported).
         for item in array.items.iter() {
             if let Some(item_type_id) = self.check_type_of_value_expression(item) {
                 item_type_ids.push(item_type_id);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -34,9 +34,8 @@ impl Pass<'_> {
     }
 
     /// The typing registered for `node`, checking nothing: an overload set is
-    /// handed on undetermined, so a callee can still select from it. Every
-    /// expression registers its typing during the pass, so this is a plain
-    /// lookup and repeating it for the same node reports nothing twice.
+    /// handed on undetermined, so a callee can still select from it. This is a
+    /// plain lookup for the typing each expression registers during the pass.
     #[inline]
     pub(super) fn raw_typing_of_expression(&self, node: &ir::Expression) -> Typing {
         // Every expression variant registers its typing in the binder during
@@ -379,8 +378,17 @@ impl Pass<'_> {
         array: &ir::ArrayExpression,
     ) -> Option<TypeId> {
         let mut item_type_ids: Vec<TypeId> = Vec::with_capacity(array.items.len());
+        let mut all_typed = true;
         for item in array.items.iter() {
-            item_type_ids.push(self.check_type_of_value_expression(item)?);
+            if let Some(item_type_id) = self.check_type_of_value_expression(item) {
+                item_type_ids.push(item_type_id);
+            } else {
+                all_typed = false;
+            }
+        }
+        if !all_typed {
+            // Some array element failed to type as a value
+            return None;
         }
         let element_type = self.types.type_of_array_literal(&item_type_ids)?;
         Some(
@@ -871,17 +879,17 @@ impl Pass<'_> {
         }
     }
 
-    pub(super) fn collect_named_argument_types(
+    pub(super) fn collect_named_argument_types<'a>(
         &mut self,
-        arguments: &[ir::NamedArgument],
-    ) -> Option<Vec<(String, TypeId)>> {
+        arguments: &'a [ir::NamedArgument],
+    ) -> Option<Vec<(&'a str, TypeId)>> {
         // As in `collect_positional_argument_types`, every argument is checked
         // before the result is folded.
         let mut types = Vec::with_capacity(arguments.len());
         let mut all_typed = true;
         for argument in arguments {
             match self.check_type_of_value_expression(&argument.value) {
-                Some(type_id) => types.push((argument.name.unparse().to_string(), type_id)),
+                Some(type_id) => types.push((argument.name.unparse(), type_id)),
                 None => all_typed = false,
             }
         }

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -88,6 +88,30 @@ impl Pass<'_> {
         }
     }
 
+    /// Checks that every argument in `arguments` is a value, for a call that
+    /// resolves no overloads and so has no use for their types: a modifier
+    /// invocation, a base-constructor call, or an inheritance specifier.
+    // TODO: named arguments are not supported for modifier invocations or
+    // base-constructor calls in Solidity, but we check them here for
+    // completeness.
+    // TODO: eventually this function should be removed and replaced by calls to
+    // the argument collection function to later check that the arguments are of
+    // the appropriate type.
+    pub(super) fn check_argument_values(&mut self, arguments: &ir::ArgumentsDeclaration) {
+        match arguments {
+            ir::ArgumentsDeclaration::PositionalArguments(arguments) => {
+                for argument in arguments.iter() {
+                    self.check_type_of_value_expression(argument);
+                }
+            }
+            ir::ArgumentsDeclaration::NamedArguments(arguments) => {
+                for argument in arguments.iter() {
+                    self.check_type_of_value_expression(&argument.value);
+                }
+            }
+        }
+    }
+
     /// Reports `node` as naming something other than a value. Kept out of line
     /// for the same reason as [`Self::report_ambiguous_reference`].
     #[cold]

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -32,13 +32,28 @@ impl Pass<'_> {
         )
     }
 
-    /// The typing of `node` where its value is used, which is everywhere but
-    /// the callee of a call. Nothing can select from an overload set here, so
-    /// one that reaches this point is sunk to `Unresolved` rather than handed
-    /// on undetermined.
+    /// The typing registered for `node`, checking nothing: an overload set is
+    /// handed on undetermined, so a callee can still select from it. Every
+    /// expression registers its typing during the pass, so this is a plain
+    /// lookup and repeating it for the same node reports nothing twice.
     #[inline]
-    pub(super) fn typing_of_expression(&mut self, node: &ir::Expression) -> Typing {
-        match self.typing_of_callee_expression(node) {
+    pub(super) fn raw_typing_of_expression(&self, node: &ir::Expression) -> Typing {
+        // Every expression variant registers its typing in the binder during
+        // the pass, so we simply look it up by `NodeId`.
+        let node_id = node
+            .node_id()
+            .expect("expression should have a NodeId to look up its typing");
+        self.binder.node_typing(node_id)
+    }
+
+    /// The typing of `node` where nothing can select from an overload set, so
+    /// one that reaches this point is reported as ambiguous and sunk to
+    /// `Unresolved` rather than handed on undetermined. The typing may still
+    /// name something other than a value, so a position that requires one
+    /// should use [`Self::check_type_of_value_expression`] instead.
+    #[inline]
+    pub(super) fn check_typing_of_expression(&mut self, node: &ir::Expression) -> Typing {
+        match self.raw_typing_of_expression(node) {
             Typing::Undetermined(_) => {
                 self.report_ambiguous_reference(node);
                 Typing::Unresolved
@@ -47,15 +62,23 @@ impl Pass<'_> {
         }
     }
 
-    /// The typing `node` registered, which for a callee may be the whole
-    /// overload set: the call's arguments are what select from it.
-    pub(super) fn typing_of_callee_expression(&self, node: &ir::Expression) -> Typing {
-        // Every expression variant registers its typing in the binder during
-        // the pass, so we simply look it up by `NodeId`.
-        let node_id = node
-            .node_id()
-            .expect("expression should have a NodeId to look up its typing");
-        self.binder.node_typing(node_id)
+    /// The type of `node` in a position that requires a value. On top of
+    /// [`Self::check_typing_of_expression`], the typings that name something
+    /// which is not a value have no type here: a built-in (a namespace such as
+    /// `abi`, or a built-in function), `super`, and an uncalled `new`.
+    #[inline]
+    pub(super) fn check_type_of_value_expression(
+        &mut self,
+        node: &ir::Expression,
+    ) -> Option<TypeId> {
+        match self.check_typing_of_expression(node) {
+            Typing::BuiltIn(_) | Typing::NewExpression(_) | Typing::Super => {
+                // TODO(validation): report that the expression names a built-in,
+                // a base contract or a contract creation rather than a value.
+                None
+            }
+            typing => typing.as_type_id(),
+        }
     }
 
     /// Narrows an overload lookup for a call down to the selected candidate,
@@ -112,7 +135,8 @@ impl Pass<'_> {
 
     /// Reports `node` as a reference that matched more than one declaration.
     /// Kept out of line so that reporting, which is rare, does not stop
-    /// [`Self::typing_of_expression`] from inlining into its many callers.
+    /// [`Self::check_typing_of_expression`] from inlining into its many
+    /// callers.
     #[cold]
     #[inline(never)]
     fn report_ambiguous_reference(&mut self, node: &ir::Expression) {
@@ -176,7 +200,7 @@ impl Pass<'_> {
     /// The mobile type of one conditional branch, reporting why a branch has
     /// none.
     fn mobile_type_of_conditional_branch(&mut self, branch: &ir::Expression) -> Option<TypeId> {
-        let type_id = self.typing_of_expression(branch).as_type_id()?;
+        let type_id = self.check_type_of_value_expression(branch)?;
         match self.types.compute_mobile_type(type_id) {
             Ok(mobile) => Some(mobile),
             Err(NoMobileType::NotAValue) => {
@@ -199,12 +223,11 @@ impl Pass<'_> {
     pub(super) fn record_comparison_common_operand_type(
         &mut self,
         node_id: NodeId,
-        left_typing: &Typing,
-        right_typing: &Typing,
+        left_type_id: Option<TypeId>,
+        right_type_id: Option<TypeId>,
     ) {
-        let common = left_typing
-            .as_type_id()
-            .zip(right_typing.as_type_id())
+        let common = left_type_id
+            .zip(right_type_id)
             .and_then(|(left, right)| self.types.common_operand_type(left, right));
         self.binder.set_common_operand_type(node_id, common);
     }
@@ -215,15 +238,15 @@ impl Pass<'_> {
     /// operand types.
     pub(super) fn type_of_binary_operator_expression<F>(
         &mut self,
-        left_typing: &Typing,
-        right_typing: &Typing,
+        left_type_id: Option<TypeId>,
+        right_type_id: Option<TypeId>,
         op: F,
     ) -> Option<TypeId>
     where
         F: FnOnce(&Number, &Number) -> Option<Number>,
     {
-        let left_type_id = left_typing.as_type_id()?;
-        let right_type_id = right_typing.as_type_id()?;
+        let left_type_id = left_type_id?;
+        let right_type_id = right_type_id?;
 
         // If both operands are number constants, fold them using the given operator.
         if let (Some(left_value), Some(right_value)) = (
@@ -247,13 +270,13 @@ impl Pass<'_> {
     pub(super) fn type_of_prefix_expression(
         &mut self,
         node: &ir::PrefixExpression,
-        operand_typing: &Typing,
+        operand_type_id: Option<TypeId>,
     ) -> Option<TypeId> {
         match node.operator {
             ir::PrefixExpressionOperator::Minus(_) | ir::PrefixExpressionOperator::Tilde(_) => {
                 // Fold `-<constant>` or `~<constant>` by operating on the
                 // operand's known number value.
-                let operand_type_id = operand_typing.as_type_id()?;
+                let operand_type_id = operand_type_id?;
                 if let Some(value) = self.types.number_value_of_type_id(operand_type_id) {
                     let result = match node.operator {
                         ir::PrefixExpressionOperator::Minus(_) => value.negate(),
@@ -270,7 +293,7 @@ impl Pass<'_> {
                 }
             }
             ir::PrefixExpressionOperator::PlusPlus(_)
-            | ir::PrefixExpressionOperator::MinusMinus(_) => operand_typing.as_type_id(),
+            | ir::PrefixExpressionOperator::MinusMinus(_) => operand_type_id,
             ir::PrefixExpressionOperator::Bang(_) => {
                 // TODO(validation) SDR[49]: check that the operand is boolean
                 Some(self.types.boolean())
@@ -323,7 +346,9 @@ impl Pass<'_> {
     /// integer literal that fits a `U256`. The value is taken from the
     /// expression type to benefit from the constant folding of literals.
     fn literal_array_size(&mut self, size: &ir::Expression) -> Option<U256> {
-        let type_id = self.typing_of_expression(size).as_type_id()?;
+        // The index is already typed as a value by the enclosing index access,
+        // so this only reads back the typing it registered.
+        let type_id = self.raw_typing_of_expression(size).as_type_id()?;
         let value = self.types.number_value_of_type_id(type_id)?;
         U256::try_from(value.as_integer()?).ok()
     }
@@ -334,7 +359,7 @@ impl Pass<'_> {
     ) -> Option<TypeId> {
         let mut item_type_ids: Vec<TypeId> = Vec::with_capacity(array.items.len());
         for item in array.items.iter() {
-            item_type_ids.push(self.typing_of_expression(item).as_type_id()?);
+            item_type_ids.push(self.check_type_of_value_expression(item)?);
         }
         let element_type = self.types.type_of_array_literal(&item_type_ids)?;
         Some(
@@ -349,15 +374,15 @@ impl Pass<'_> {
 
     pub(super) fn type_of_left_typed_binary_operator_expression<F>(
         &mut self,
-        left_typing: &Typing,
-        right_typing: &Typing,
+        left_type_id: Option<TypeId>,
+        right_type_id: Option<TypeId>,
         op: F,
     ) -> Option<TypeId>
     where
         F: FnOnce(&Number, &Number) -> Option<Number>,
     {
-        let left_type_id = left_typing.as_type_id()?;
-        let right_type_id = right_typing.as_type_id()?;
+        let left_type_id = left_type_id?;
+        let right_type_id = right_type_id?;
 
         let left_value = self.types.number_value_of_type_id(left_type_id);
         let right_value = self.types.number_value_of_type_id(right_type_id);
@@ -471,7 +496,7 @@ impl Pass<'_> {
     fn type_id_of_value_receiver(&mut self, operand: &ir::Expression) -> Option<TypeId> {
         if let ir::Expression::MemberAccessExpression(member_access_expression) = operand {
             let type_id = self
-                .typing_of_expression(&member_access_expression.operand)
+                .check_typing_of_expression(&member_access_expression.operand)
                 .as_type_id()?;
             // A meta-type operand is a namespace qualifier, not
             // a runtime value, so there is no receiver to bind as an implicit
@@ -576,34 +601,37 @@ impl Pass<'_> {
         )
     }
 
-    fn typing_of_cast(&mut self, argument_typing: &Typing, target_type_id: TypeId) -> Typing {
+    fn typing_of_cast(&mut self, argument_type_id: TypeId, target_type_id: TypeId) -> Typing {
         // TODO(validation) SDR[40]: this is a cast to the given type, but we
         // need to verify that the (single) argument is convertible
-        match argument_typing.as_type_id() {
-            Some(argument_type_id) => {
-                // the resulting cast type inherits the data location of the argument
-                let argument_type = self.types.get_type_by_id(argument_type_id);
-                let type_id = if let Some(data_location) = argument_type.data_location() {
-                    let target_type = self.types.get_type_by_id(target_type_id).clone();
-                    self.types
-                        .register_type_with_data_location(target_type, data_location)
-                } else {
-                    target_type_id
-                };
-                Typing::Resolved(type_id)
-            }
-            None => Typing::Unresolved,
-        }
+        //
+        // The resulting cast type inherits the data location of the argument.
+        let argument_type = self.types.get_type_by_id(argument_type_id);
+        let type_id = if let Some(data_location) = argument_type.data_location() {
+            let target_type = self.types.get_type_by_id(target_type_id).clone();
+            self.types
+                .register_type_with_data_location(target_type, data_location)
+        } else {
+            target_type_id
+        };
+        Typing::Resolved(type_id)
     }
 
-    pub(super) fn collect_positional_argument_typings(
+    pub(super) fn collect_positional_argument_types(
         &mut self,
         arguments: &[ir::Expression],
-    ) -> Vec<Typing> {
-        arguments
-            .iter()
-            .map(|argument| self.typing_of_expression(argument))
-            .collect::<Vec<_>>()
+    ) -> Option<Vec<TypeId>> {
+        // Every argument is checked before the result is folded, so one that has
+        // no type does not stop the rest from being checked (and reported).
+        let mut types = Vec::with_capacity(arguments.len());
+        let mut all_typed = true;
+        for argument in arguments {
+            match self.check_type_of_value_expression(argument) {
+                Some(type_id) => types.push(type_id),
+                None => all_typed = false,
+            }
+        }
+        all_typed.then_some(types)
     }
 
     pub(super) fn typing_of_function_call_with_positional_arguments(
@@ -611,8 +639,8 @@ impl Pass<'_> {
         node: &ir::FunctionCallExpression,
         arguments: &[ir::Expression],
     ) -> Typing {
-        let operand_typing = self.typing_of_callee_expression(&node.operand);
-        let argument_typings = self.collect_positional_argument_typings(arguments);
+        let operand_typing = self.raw_typing_of_expression(&node.operand);
+        let argument_types = self.collect_positional_argument_types(arguments);
 
         match operand_typing {
             Typing::Unresolved => {
@@ -639,7 +667,7 @@ impl Pass<'_> {
             Typing::BuiltIn(built_in) => {
                 match self
                     .built_ins_resolver()
-                    .type_of_function_call(&built_in, &argument_typings)
+                    .type_of_function_call(&built_in, argument_types.as_deref())
                 {
                     Ok(type_id) => Typing::Resolved(type_id),
                     Err(error) => {
@@ -648,17 +676,23 @@ impl Pass<'_> {
                     }
                 }
             }
-
             Typing::Resolved(type_id) => self.typing_of_type_called_with_positional_arguments(
                 node,
                 type_id,
-                &argument_typings,
+                argument_types.as_deref(),
             ),
             Typing::Undetermined(type_ids) => {
+                // No overload can accept an argument that has no type, so the
+                // arguments cannot select one. The argument is reported where it
+                // fails, and reporting the call as having no candidate on top of
+                // that would just be a cascade.
+                let Some(argument_types) = argument_types else {
+                    return Typing::Unresolved;
+                };
                 let receiver_type_id = self.type_id_of_value_receiver(&node.operand);
                 let overload_match = self.lookup_function_matching_positional_arguments(
                     &type_ids,
-                    &argument_typings,
+                    &argument_types,
                     receiver_type_id,
                 );
                 let candidate = self.select_overload(&node.operand, overload_match);
@@ -671,7 +705,7 @@ impl Pass<'_> {
                     self.typing_of_type_called_with_positional_arguments(
                         node,
                         candidate_type_id,
-                        &argument_typings,
+                        Some(&argument_types),
                     )
                 } else {
                     Typing::Unresolved
@@ -703,14 +737,14 @@ impl Pass<'_> {
     /// Types a call whose operand is (or was disambiguated to) `type_id`: a
     /// function value is an actual call, a meta type is a cast (or a struct
     /// construction), and the user meta type of a function is a non-callable
-    /// declaration reached through a contract/interface type name. Anything
-    /// else, including a modifier and the alias of an imported file, is not
-    /// callable at all.
+    /// declaration reached through a contract/interface type name.
+    /// `argument_types` remains optional because there are cascading
+    /// diagnostics that are worth reporting regardless.
     fn typing_of_type_called_with_positional_arguments(
         &mut self,
         node: &ir::FunctionCallExpression,
         type_id: TypeId,
-        argument_typings: &[Typing],
+        argument_types: Option<&[TypeId]>,
     ) -> Typing {
         match self.types.get_type_by_id(type_id) {
             Type::Function(FunctionType {
@@ -731,8 +765,8 @@ impl Pass<'_> {
             }) => {
                 // This is an explicit cast to the (meta-)type, eg. `uint(x)`.
                 let target_type_id = *target_type_id;
-                if argument_typings.len() == 1 {
-                    self.typing_of_cast(&argument_typings[0], target_type_id)
+                if let Some([argument_type_id]) = argument_types {
+                    self.typing_of_cast(*argument_type_id, target_type_id)
                 } else {
                     Typing::Unresolved
                 }
@@ -816,19 +850,21 @@ impl Pass<'_> {
         }
     }
 
-    pub(super) fn collect_named_argument_typings(
+    pub(super) fn collect_named_argument_types(
         &mut self,
         arguments: &[ir::NamedArgument],
-    ) -> Vec<(String, Typing)> {
-        arguments
-            .iter()
-            .map(|argument| {
-                (
-                    argument.name.unparse().to_string(),
-                    self.typing_of_expression(&argument.value),
-                )
-            })
-            .collect::<Vec<_>>()
+    ) -> Option<Vec<(String, TypeId)>> {
+        // As in `collect_positional_argument_types`, every argument is checked
+        // before the result is folded.
+        let mut types = Vec::with_capacity(arguments.len());
+        let mut all_typed = true;
+        for argument in arguments {
+            match self.check_type_of_value_expression(&argument.value) {
+                Some(type_id) => types.push((argument.name.unparse().to_string(), type_id)),
+                None => all_typed = false,
+            }
+        }
+        all_typed.then_some(types)
     }
 
     pub(super) fn typing_of_function_call_with_named_arguments(
@@ -836,7 +872,8 @@ impl Pass<'_> {
         node: &ir::FunctionCallExpression,
         arguments: &[ir::NamedArgument],
     ) -> Typing {
-        let operand_typing = self.typing_of_callee_expression(&node.operand);
+        let operand_typing = self.raw_typing_of_expression(&node.operand);
+        let argument_types = self.collect_named_argument_types(arguments);
 
         let (typing, definition_id) = match operand_typing {
             Typing::Unresolved => {
@@ -853,23 +890,29 @@ impl Pass<'_> {
                 self.typing_of_type_called_with_named_arguments(node, type_id)
             }
             Typing::Undetermined(type_ids) => {
-                let receiver_type_id = self.type_id_of_value_receiver(&node.operand);
-                let argument_typings = self.collect_named_argument_typings(arguments);
-                let overload_match = self.lookup_function_matching_named_arguments(
-                    &type_ids,
-                    &argument_typings,
-                    receiver_type_id,
-                );
-                let candidate = self.select_overload(&node.operand, overload_match);
+                // As in the positional form, an argument without a type cannot
+                // select an overload, and reporting the call would only cascade.
+                match argument_types {
+                    None => (Typing::Unresolved, None),
+                    Some(argument_types) => {
+                        let receiver_type_id = self.type_id_of_value_receiver(&node.operand);
+                        let overload_match = self.lookup_function_matching_named_arguments(
+                            &type_ids,
+                            &argument_types,
+                            receiver_type_id,
+                        );
+                        let candidate = self.select_overload(&node.operand, overload_match);
 
-                if let Some(candidate_type_id) = candidate {
-                    // The operand disambiguates to the selected overload, even
-                    // when calling it turns out to be invalid
-                    self.fixup_operand_expression(&node.operand, candidate_type_id);
+                        if let Some(candidate_type_id) = candidate {
+                            // The operand disambiguates to the selected overload,
+                            // even when calling it turns out to be invalid
+                            self.fixup_operand_expression(&node.operand, candidate_type_id);
 
-                    self.typing_of_type_called_with_named_arguments(node, candidate_type_id)
-                } else {
-                    (Typing::Unresolved, None)
+                            self.typing_of_type_called_with_named_arguments(node, candidate_type_id)
+                        } else {
+                            (Typing::Unresolved, None)
+                        }
+                    }
                 }
             }
             Typing::NewExpression(type_id) => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -63,6 +63,14 @@ impl Visitor for Pass<'_> {
         false
     }
 
+    fn leave_inheritance_type(&mut self, node: &ir::InheritanceType) {
+        // The arguments of a base contract (eg. `is Base(1)`) are its
+        // constructor's, so they are values.
+        if let Some(arguments) = &node.arguments {
+            self.check_argument_values(arguments);
+        }
+    }
+
     fn enter_interface_definition(&mut self, node: &ir::InterfaceDefinition) -> bool {
         self.enter_scope_for_node_id(node.id());
         true
@@ -92,6 +100,28 @@ impl Visitor for Pass<'_> {
 
     fn leave_function_definition(&mut self, node: &ir::FunctionDefinition) {
         self.leave_scope_for_node_id(node.id());
+    }
+
+    fn leave_modifier_invocation(&mut self, node: &ir::ModifierInvocation) {
+        // Both a modifier's arguments and, on a constructor, a base
+        // constructor's are values.
+        if let Some(arguments) = &node.arguments {
+            self.check_argument_values(arguments);
+        }
+    }
+
+    fn leave_state_variable_definition(&mut self, node: &ir::StateVariableDefinition) {
+        // The initialiser's value is bound to the declared variable, as in
+        // `leave_variable_declaration_statement`.
+        if let Some(value) = &node.value {
+            self.check_type_of_value_expression(value);
+        }
+    }
+
+    fn leave_constant_definition(&mut self, node: &ir::ConstantDefinition) {
+        if let Some(value) = &node.value {
+            self.check_type_of_value_expression(value);
+        }
     }
 
     fn enter_block(&mut self, node: &ir::Block) -> bool {
@@ -575,6 +605,12 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_call_options_expression(&mut self, node: &ir::CallOptionsExpression) {
+        // Each option is passed to the call (eg. the ether `foo{value: 3}`
+        // sends), so it is a value.
+        for option in node.options.iter() {
+            self.check_type_of_value_expression(&option.value);
+        }
+
         // `foo{value: 3}` partially applies but is still a callee, so an
         // overload set has to survive to the enclosing call.
         let operand_typing = self.raw_typing_of_expression(&node.operand);

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -110,9 +110,19 @@ impl Visitor for Pass<'_> {
 
     fn leave_for_statement(&mut self, node: &ir::ForStatement) {
         // The initialisation and the condition are expression statements, so
-        // they already require a value; the iterator is only reached here.
+        // they are already handled by [`Self::leave_expression_statement`],
+        // which does not require a value. That is right for the initialisation
+        // but not for the condition. Keep in sync.
+        // __SLANG_EXPRESSION_STATEMENT_TYPE__
+        //
+        // TODO(validation): the condition does require a value, of a type
+        // convertible to boolean. Caveat: using
+        // `check_type_of_value_expression` here would report an ambiguous
+        // reference a second time, since the expression statement it is written
+        // as has already checked (and reported) the same node.
         if let Some(iterator) = &node.iterator {
-            self.check_type_of_value_expression(iterator);
+            // Check that the iterator expression type resolves unambiguously
+            self.check_typing_of_expression(iterator);
         }
         self.leave_scope_for_node_id(node.id());
     }
@@ -669,11 +679,21 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_revert_statement(&mut self, node: &ir::RevertStatement) {
-        if let ir::ArgumentsDeclaration::NamedArguments(named_arguments) = &node.arguments {
-            let definition_id = self
-                .followed_resolution_of_reference(node.error.last().unwrap().id())
-                .and_then(|resolution| resolution.as_definition_id());
-            self.resolve_named_arguments(named_arguments, definition_id);
+        match &node.arguments {
+            ir::ArgumentsDeclaration::PositionalArguments(positional_arguments) => {
+                // Collect the argument types to ensure all of them type to a value
+                // TODO(validation): check that the types match the error definition
+                self.collect_positional_argument_types(positional_arguments);
+            }
+            ir::ArgumentsDeclaration::NamedArguments(named_arguments) => {
+                // Collect the argument types to ensure all of them type to a value
+                // TODO(validation): check that the types match the error definition
+                self.collect_named_argument_types(named_arguments);
+                let definition_id = self
+                    .followed_resolution_of_reference(node.error.last().unwrap().id())
+                    .and_then(|resolution| resolution.as_definition_id());
+                self.resolve_named_arguments(named_arguments, definition_id);
+            }
         }
     }
 
@@ -707,6 +727,9 @@ impl Visitor for Pass<'_> {
         // own right, and `super;` or `data.pop;` are accepted as statements
         // with no effect. So this only checks the expression, without requiring
         // it to be a value.
+        // NOTE: initializer and condition of a for statement are expression
+        // statements, so keep the behaviour in sync with
+        // [`Self::leave_for_statement`]. __SLANG_EXPRESSION_STATEMENT_TYPE__
         self.check_typing_of_expression(&node.expression);
     }
 

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -109,6 +109,11 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_for_statement(&mut self, node: &ir::ForStatement) {
+        // The initialisation and the condition are expression statements, so
+        // they already require a value; the iterator is only reached here.
+        if let Some(iterator) = &node.iterator {
+            self.check_type_of_value_expression(iterator);
+        }
         self.leave_scope_for_node_id(node.id());
     }
 
@@ -185,81 +190,85 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_assignment_expression(&mut self, node: &ir::AssignmentExpression) {
-        let type_id = self.typing_of_expression(&node.left_operand).as_type_id();
-        self.typing_of_expression(&node.right_operand);
+        let type_id = self.check_type_of_value_expression(&node.left_operand);
+        self.check_type_of_value_expression(&node.right_operand);
         // TODO(validation) SDR[59]: check that the type of right_operand can be applied
         // to the left by means of the operator
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_conditional_expression(&mut self, node: &ir::ConditionalExpression) {
-        self.typing_of_expression(&node.operand);
+        self.check_type_of_value_expression(&node.operand);
         let type_id = self.type_of_conditional_expression(node);
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_or_expression(&mut self, node: &ir::OrExpression) {
         // TODO(validation) SDR[57]: check that both operands are boolean
+        self.check_type_of_value_expression(&node.left_operand);
+        self.check_type_of_value_expression(&node.right_operand);
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
     }
 
     fn leave_and_expression(&mut self, node: &ir::AndExpression) {
         // TODO(validation) SDR[57]: check that both operands are boolean
+        self.check_type_of_value_expression(&node.left_operand);
+        self.check_type_of_value_expression(&node.right_operand);
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
     }
 
     fn leave_equality_expression(&mut self, node: &ir::EqualityExpression) {
         // TODO(validation) SDR[55]: check that both operands have a compatible type
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
-        self.record_comparison_common_operand_type(node.id(), &left, &right);
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
+        self.record_comparison_common_operand_type(node.id(), left, right);
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
-        self.resolve_operator_function(node.id(), (&node.operator).into(), left.as_type_id(), 2);
+        self.resolve_operator_function(node.id(), (&node.operator).into(), left, 2);
     }
 
     fn leave_inequality_expression(&mut self, node: &ir::InequalityExpression) {
         // TODO(validation) SDR[55]: check that both operands have a compatible type
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
-        self.record_comparison_common_operand_type(node.id(), &left, &right);
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
+        self.record_comparison_common_operand_type(node.id(), left, right);
         self.binder
             .set_node_type(node.id(), Some(self.types.boolean()));
-        self.resolve_operator_function(node.id(), (&node.operator).into(), left.as_type_id(), 2);
+        self.resolve_operator_function(node.id(), (&node.operator).into(), left, 2);
     }
 
     fn leave_bitwise_or_expression(&mut self, node: &ir::BitwiseOrExpression) {
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
-        let type_id = self.type_of_binary_operator_expression(&left, &right, |l, r| l.bit_or(r));
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
+        let type_id = self.type_of_binary_operator_expression(left, right, |l, r| l.bit_or(r));
         self.binder.set_node_type(node.id(), type_id);
-        self.resolve_operator_function(node.id(), UsingOperator::Bar, left.as_type_id(), 2);
+        self.resolve_operator_function(node.id(), UsingOperator::Bar, left, 2);
     }
 
     fn leave_bitwise_xor_expression(&mut self, node: &ir::BitwiseXorExpression) {
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
-        let type_id = self.type_of_binary_operator_expression(&left, &right, |l, r| l.bit_xor(r));
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
+        let type_id = self.type_of_binary_operator_expression(left, right, |l, r| l.bit_xor(r));
         self.binder.set_node_type(node.id(), type_id);
-        self.resolve_operator_function(node.id(), UsingOperator::Caret, left.as_type_id(), 2);
+        self.resolve_operator_function(node.id(), UsingOperator::Caret, left, 2);
     }
 
     fn leave_bitwise_and_expression(&mut self, node: &ir::BitwiseAndExpression) {
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
-        let type_id = self.type_of_binary_operator_expression(&left, &right, |l, r| l.bit_and(r));
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
+        let type_id = self.type_of_binary_operator_expression(left, right, |l, r| l.bit_and(r));
         self.binder.set_node_type(node.id(), type_id);
-        self.resolve_operator_function(node.id(), UsingOperator::Ampersand, left.as_type_id(), 2);
+        self.resolve_operator_function(node.id(), UsingOperator::Ampersand, left, 2);
     }
 
     fn leave_shift_expression(&mut self, node: &ir::ShiftExpression) {
         // TODO(validation) SDR[54]: check that the left operand is an integer and the
         // right operand is an _unsigned_ integer
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
-        let type_id = self.type_of_left_typed_binary_operator_expression(&left, &right, |l, r| {
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
+        let type_id = self.type_of_left_typed_binary_operator_expression(left, right, |l, r| {
             match &node.operator {
                 ir::ShiftExpressionOperator::LessThanLessThan(_) => l.shl(r),
                 ir::ShiftExpressionOperator::GreaterThanGreaterThan(_) => l.shr(r),
@@ -270,64 +279,69 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_additive_expression(&mut self, node: &ir::AdditiveExpression) {
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
         let type_id =
-            self.type_of_binary_operator_expression(&left, &right, |l, r| match &node.operator {
+            self.type_of_binary_operator_expression(left, right, |l, r| match &node.operator {
                 ir::AdditiveExpressionOperator::Plus(_) => Some(l.add(r)),
                 ir::AdditiveExpressionOperator::Minus(_) => Some(l.sub(r)),
             });
         self.binder.set_node_type(node.id(), type_id);
-        self.resolve_operator_function(node.id(), (&node.operator).into(), left.as_type_id(), 2);
+        self.resolve_operator_function(node.id(), (&node.operator).into(), left, 2);
     }
 
     fn leave_multiplicative_expression(&mut self, node: &ir::MultiplicativeExpression) {
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
         let type_id =
-            self.type_of_binary_operator_expression(&left, &right, |l, r| match &node.operator {
+            self.type_of_binary_operator_expression(left, right, |l, r| match &node.operator {
                 ir::MultiplicativeExpressionOperator::Asterisk(_) => Some(l.mul(r)),
                 ir::MultiplicativeExpressionOperator::Slash(_) => l.div(r),
                 ir::MultiplicativeExpressionOperator::Percent(_) => l.rem(r),
             });
         self.binder.set_node_type(node.id(), type_id);
-        self.resolve_operator_function(node.id(), (&node.operator).into(), left.as_type_id(), 2);
+        self.resolve_operator_function(node.id(), (&node.operator).into(), left, 2);
     }
 
     fn leave_exponentiation_expression(&mut self, node: &ir::ExponentiationExpression) {
-        let left = self.typing_of_expression(&node.left_operand);
-        let right = self.typing_of_expression(&node.right_operand);
+        let left = self.check_type_of_value_expression(&node.left_operand);
+        let right = self.check_type_of_value_expression(&node.right_operand);
         let type_id =
-            self.type_of_left_typed_binary_operator_expression(&left, &right, |l, r| l.pow(r));
+            self.type_of_left_typed_binary_operator_expression(left, right, |l, r| l.pow(r));
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_postfix_expression(&mut self, node: &ir::PostfixExpression) {
         // TODO(validation) SDR[52]: check that the operand is an integer
-        let type_id = self.typing_of_expression(&node.operand).as_type_id();
+        let type_id = self.check_type_of_value_expression(&node.operand);
         self.binder.set_node_type(node.id(), type_id);
     }
 
     fn leave_prefix_expression(&mut self, node: &ir::PrefixExpression) {
-        let operand = self.typing_of_expression(&node.operand);
-        let type_id = self.type_of_prefix_expression(node, &operand);
+        let operand = self.check_type_of_value_expression(&node.operand);
+        let type_id = self.type_of_prefix_expression(node, operand);
         self.binder.set_node_type(node.id(), type_id);
         if let Ok(operator) = UsingOperator::try_from(&node.operator) {
-            self.resolve_operator_function(node.id(), operator, operand.as_type_id(), 1);
+            self.resolve_operator_function(node.id(), operator, operand, 1);
         }
     }
 
     fn leave_tuple_expression(&mut self, node: &ir::TupleExpression) {
         let typing = if node.items.len() == 1 {
+            // Parentheses are transparent: the typing passes through untouched,
+            // except for overload sets which are not allowed, so `(super).f()`
+            // and `(abi).encode()` resolve as the unwrapped form does. Whether
+            // a value is required is for the enclosing context to decide, and
+            // it sees this same typing.
             match &node.items.first().unwrap().expression {
-                Some(expression) => self.typing_of_expression(expression),
+                Some(expression) => self.check_typing_of_expression(expression),
                 None => Typing::Unresolved,
             }
         } else {
             let mut types = Vec::new();
             for item in node.items.iter() {
                 let type_id = match &item.expression {
-                    Some(expression) => self.typing_of_expression(expression).as_type_id(),
+                    Some(expression) => self.check_type_of_value_expression(expression),
                     None => None,
                 };
                 types.push(type_id.unwrap_or(self.types.void()));
@@ -341,7 +355,7 @@ impl Visitor for Pass<'_> {
     fn leave_member_access_expression(&mut self, node: &ir::MemberAccessExpression) {
         // we need to resolve the identifier at this point that we already have
         // typing information of the operand expression
-        let operand_typing = self.typing_of_expression(&node.operand);
+        let operand_typing = self.check_typing_of_expression(&node.operand);
         let member_resolution =
             self.resolve_symbol_in_typing(&operand_typing, node.member.unparse());
         let resolution = filter_overriden_definitions(self.binder, self.types, member_resolution);
@@ -404,8 +418,17 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_index_access_expression(&mut self, node: &ir::IndexAccessExpression) {
-        let typing = match self.typing_of_expression(&node.operand) {
-            Typing::Resolved(operand_type_id) => {
+        // The index (or the slice bounds) is a value, even where the operand is
+        // a type name and the index is its array length.
+        for index in [node.start.as_ref(), node.end.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            self.check_type_of_value_expression(index);
+        }
+
+        let typing = match self.check_type_of_value_expression(&node.operand) {
+            Some(operand_type_id) => {
                 match self.types.get_type_by_id(operand_type_id) {
                     Type::Array(ArrayType {
                         element_type,
@@ -499,7 +522,7 @@ impl Visitor for Pass<'_> {
                     }
                 }
             }
-            _ => Typing::Unresolved,
+            None => Typing::Unresolved,
         };
         self.binder.set_node_typing(node.id(), typing);
     }
@@ -544,7 +567,7 @@ impl Visitor for Pass<'_> {
     fn leave_call_options_expression(&mut self, node: &ir::CallOptionsExpression) {
         // `foo{value: 3}` partially applies but is still a callee, so an
         // overload set has to survive to the enclosing call.
-        let operand_typing = self.typing_of_callee_expression(&node.operand);
+        let operand_typing = self.raw_typing_of_expression(&node.operand);
 
         // Pre-applying call options (eg. `foo{value: 3}`) partially applies the
         // function.
@@ -599,14 +622,16 @@ impl Visitor for Pass<'_> {
         let event_resolution = self.followed_resolution_of_reference(event_reference_id);
         match &node.arguments {
             ir::ArgumentsDeclaration::PositionalArguments(positional_arguments) => {
-                // For positional arguments, resolve ambiguity of overloads only
-                if let Some(Resolution::Ambiguous(definition_ids)) = &event_resolution {
-                    let argument_typings =
-                        self.collect_positional_argument_typings(positional_arguments);
-                    let overload_match = self.lookup_event_matching_positional_arguments(
-                        definition_ids,
-                        &argument_typings,
-                    );
+                // Collected for every emit, not just an ambiguous one, so that
+                // an argument value is checked either way. An argument without a
+                // type cannot select an overload, so disambiguation is skipped
+                // rather than reported on top of the argument's own failure.
+                let argument_types = self.collect_positional_argument_types(positional_arguments);
+                if let (Some(Resolution::Ambiguous(definition_ids)), Some(argument_types)) =
+                    (&event_resolution, &argument_types)
+                {
+                    let overload_match = self
+                        .lookup_event_matching_positional_arguments(definition_ids, argument_types);
                     let candidate =
                         self.select_event_overload(node.event.last().unwrap(), overload_match);
                     if let Some(candidate) = candidate {
@@ -618,13 +643,11 @@ impl Visitor for Pass<'_> {
             }
             ir::ArgumentsDeclaration::NamedArguments(named_arguments) => {
                 // For named arguments, we need to resolve ambiguity and the named arguments
-                let definition_id = match &event_resolution {
-                    Some(Resolution::Ambiguous(definition_ids)) => {
-                        let argument_typings = self.collect_named_argument_typings(named_arguments);
-                        let overload_match = self.lookup_event_matching_named_arguments(
-                            definition_ids,
-                            &argument_typings,
-                        );
+                let argument_types = self.collect_named_argument_types(named_arguments);
+                let definition_id = match (&event_resolution, &argument_types) {
+                    (Some(Resolution::Ambiguous(definition_ids)), Some(argument_types)) => {
+                        let overload_match = self
+                            .lookup_event_matching_named_arguments(definition_ids, argument_types);
                         let candidate =
                             self.select_event_overload(node.event.last().unwrap(), overload_match);
                         if let Some(candidate) = candidate {
@@ -636,7 +659,7 @@ impl Visitor for Pass<'_> {
                         }
                         candidate
                     }
-                    Some(Resolution::Definition(definition_id)) => Some(*definition_id),
+                    (Some(Resolution::Definition(definition_id)), _) => Some(*definition_id),
                     _ => None,
                 };
                 // resolve names in named arguments
@@ -659,11 +682,11 @@ impl Visitor for Pass<'_> {
         match &node.target {
             ir::VariableDeclarationTarget::SingleTypedDeclaration(declaration) => {
                 if let Some(value) = &declaration.value {
-                    self.typing_of_expression(value);
+                    self.check_type_of_value_expression(value);
                 }
             }
             ir::VariableDeclarationTarget::MultiTypedDeclaration(declaration) => {
-                self.typing_of_expression(&declaration.value);
+                self.check_type_of_value_expression(&declaration.value);
             }
         }
 
@@ -674,20 +697,32 @@ impl Visitor for Pass<'_> {
 
     fn leave_return_statement(&mut self, node: &ir::ReturnStatement) {
         if let Some(expression) = &node.expression {
-            self.typing_of_expression(expression);
+            self.check_type_of_value_expression(expression);
         }
     }
 
     fn leave_expression_statement(&mut self, node: &ir::ExpressionStatement) {
-        self.typing_of_expression(&node.expression);
+        // A modifier's placeholder (`_`) is the one built-in that is a statement
+        // rather than a value, so it is exempt from requiring one here.
+        if matches!(
+            self.raw_typing_of_expression(&node.expression),
+            Typing::BuiltIn(InternalBuiltIn::ModifierUnderscore)
+        ) {
+            return;
+        }
+        self.check_type_of_value_expression(&node.expression);
     }
 
     fn leave_if_statement(&mut self, node: &ir::IfStatement) {
-        self.typing_of_expression(&node.condition);
+        self.check_type_of_value_expression(&node.condition);
     }
 
     fn leave_while_statement(&mut self, node: &ir::WhileStatement) {
-        self.typing_of_expression(&node.condition);
+        self.check_type_of_value_expression(&node.condition);
+    }
+
+    fn leave_do_while_statement(&mut self, node: &ir::DoWhileStatement) {
+        self.check_type_of_value_expression(&node.condition);
     }
 
     fn enter_yul_block(&mut self, _node: &ir::YulBlock) -> bool {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -702,15 +702,12 @@ impl Visitor for Pass<'_> {
     }
 
     fn leave_expression_statement(&mut self, node: &ir::ExpressionStatement) {
-        // A modifier's placeholder (`_`) is the one built-in that is a statement
-        // rather than a value, so it is exempt from requiring one here.
-        if matches!(
-            self.raw_typing_of_expression(&node.expression),
-            Typing::BuiltIn(InternalBuiltIn::ModifierUnderscore)
-        ) {
-            return;
-        }
-        self.check_type_of_value_expression(&node.expression);
+        // A statement consumes nothing, so naming something other than a value
+        // is allowed here: a modifier's `_` placeholder is a statement in its
+        // own right, and `super;` or `data.pop;` are accepted as statements
+        // with no effect. So this only checks the expression, without requiring
+        // it to be a value.
+        self.check_typing_of_expression(&node.expression);
     }
 
     fn leave_if_statement(&mut self, node: &ir::IfStatement) {

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -790,6 +790,11 @@ mod expressions {
     }
 
     #[test]
+    fn parenthesised_operand() -> Result<()> {
+        run("expressions", "parenthesised_operand")
+    }
+
+    #[test]
     fn require_named_args() -> Result<()> {
         run("expressions", "require_named_args")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -67,6 +67,14 @@ mod resolution {
         }
 
         #[test]
+        fn overloaded_call_parenthesised() -> Result<()> {
+            run(
+                "resolution/ambiguous_reference",
+                "overloaded_call_parenthesised",
+            )
+        }
+
+        #[test]
         fn overloaded_event() -> Result<()> {
             run("resolution/ambiguous_reference", "overloaded_event")
         }
@@ -3825,6 +3833,19 @@ mod type_system {
         use super::*;
 
         #[test]
+        fn array_literal_item() -> Result<()> {
+            run("type_system/expression_not_a_value", "array_literal_item")
+        }
+
+        #[test]
+        fn base_constructor_argument() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "base_constructor_argument",
+            )
+        }
+
+        #[test]
         fn built_in_function() -> Result<()> {
             run("type_system/expression_not_a_value", "built_in_function")
         }
@@ -3837,6 +3858,11 @@ mod type_system {
         #[test]
         fn call_argument() -> Result<()> {
             run("type_system/expression_not_a_value", "call_argument")
+        }
+
+        #[test]
+        fn call_option_value() -> Result<()> {
+            run("type_system/expression_not_a_value", "call_option_value")
         }
 
         #[test]
@@ -3869,6 +3895,50 @@ mod type_system {
         }
 
         #[test]
+        fn constant_initializer() -> Result<()> {
+            run("type_system/expression_not_a_value", "constant_initializer")
+        }
+
+        #[test]
+        fn emit_argument() -> Result<()> {
+            run("type_system/expression_not_a_value", "emit_argument")
+        }
+
+        #[test]
+        fn index_access_index() -> Result<()> {
+            run("type_system/expression_not_a_value", "index_access_index")
+        }
+
+        #[test]
+        fn inheritance_specifier_argument() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "inheritance_specifier_argument",
+            )
+        }
+
+        #[test]
+        fn logical_operator_operand() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "logical_operator_operand",
+            )
+        }
+
+        #[test]
+        fn loop_condition() -> Result<()> {
+            run("type_system/expression_not_a_value", "loop_condition")
+        }
+
+        #[test]
+        fn modifier_invocation_argument() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "modifier_invocation_argument",
+            )
+        }
+
+        #[test]
         fn modifier_placeholder() -> Result<()> {
             run("type_system/expression_not_a_value", "modifier_placeholder")
         }
@@ -3879,8 +3949,26 @@ mod type_system {
         }
 
         #[test]
+        fn named_argument() -> Result<()> {
+            run("type_system/expression_not_a_value", "named_argument")
+        }
+
+        #[test]
         fn operator_operand() -> Result<()> {
             run("type_system/expression_not_a_value", "operator_operand")
+        }
+
+        #[test]
+        fn revert_argument() -> Result<()> {
+            run("type_system/expression_not_a_value", "revert_argument")
+        }
+
+        #[test]
+        fn state_variable_initializer() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "state_variable_initializer",
+            )
         }
 
         #[test]
@@ -3921,6 +4009,14 @@ mod type_system {
         }
 
         #[test]
+        fn statement_for_iterator() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "statement_for_iterator",
+            )
+        }
+
+        #[test]
         fn statement_super() -> Result<()> {
             run("type_system/expression_not_a_value", "statement_super")
         }
@@ -3928,6 +4024,11 @@ mod type_system {
         #[test]
         fn super_reference() -> Result<()> {
             run("type_system/expression_not_a_value", "super_reference")
+        }
+
+        #[test]
+        fn tuple_component() -> Result<()> {
+            run("type_system/expression_not_a_value", "tuple_component")
         }
 
         #[test]

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -3825,6 +3825,26 @@ mod type_system {
         use super::*;
 
         #[test]
+        fn built_in_function() -> Result<()> {
+            run("type_system/expression_not_a_value", "built_in_function")
+        }
+
+        #[test]
+        fn built_in_namespace() -> Result<()> {
+            run("type_system/expression_not_a_value", "built_in_namespace")
+        }
+
+        #[test]
+        fn call_argument() -> Result<()> {
+            run("type_system/expression_not_a_value", "call_argument")
+        }
+
+        #[test]
+        fn condition() -> Result<()> {
+            run("type_system/expression_not_a_value", "condition")
+        }
+
+        #[test]
         fn conditional_elementary_type_name_branches() -> Result<()> {
             run(
                 "type_system/expression_not_a_value",
@@ -3849,8 +3869,70 @@ mod type_system {
         }
 
         #[test]
+        fn modifier_placeholder() -> Result<()> {
+            run("type_system/expression_not_a_value", "modifier_placeholder")
+        }
+
+        #[test]
         fn module_aliases() -> Result<()> {
             run("type_system/expression_not_a_value", "module_aliases")
+        }
+
+        #[test]
+        fn operator_operand() -> Result<()> {
+            run("type_system/expression_not_a_value", "operator_operand")
+        }
+
+        #[test]
+        fn statement_address_transfer() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "statement_address_transfer",
+            )
+        }
+
+        #[test]
+        fn statement_array_pop() -> Result<()> {
+            run("type_system/expression_not_a_value", "statement_array_pop")
+        }
+
+        #[test]
+        fn statement_built_in_function() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "statement_built_in_function",
+            )
+        }
+
+        #[test]
+        fn statement_built_in_member() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "statement_built_in_member",
+            )
+        }
+
+        #[test]
+        fn statement_built_in_namespace() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "statement_built_in_namespace",
+            )
+        }
+
+        #[test]
+        fn statement_super() -> Result<()> {
+            run("type_system/expression_not_a_value", "statement_super")
+        }
+
+        #[test]
+        fn super_reference() -> Result<()> {
+            run("type_system/expression_not_a_value", "super_reference")
+        }
+
+        #[test]
+        fn uncalled_new() -> Result<()> {
+            run("type_system/expression_not_a_value", "uncalled_new")
         }
     }
 

--- a/crates/solidity-v2/testing/snapshots/binder_output/expressions/parenthesised_operand/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/expressions/parenthesised_operand/generated/0.8.0-success.txt
@@ -1,0 +1,67 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (5):
+- Def: #1 ["TestBase" @ input.sol:1:10] (contract)
+- Def: #2 ["g" @ input.sol:2:12] (function, type: function () returns uint256)
+- Def: #3 ["Test" @ input.sol:7:10] (contract)
+- Def: #4 ["g" @ input.sol:8:12] (function, type: function () returns uint256)
+- Def: #5 ["parenthesised" @ input.sol:12:12] (function, type: function () returns void)
+
+------------------------------------------------------------------------
+
+References (7):
+- Ref: ["TestBase" @ input.sol:7:18] -> #1
+- Ref: ["g" @ input.sol:15:11] -> #2
+- Ref: ["g" @ input.sol:16:13] -> #2
+- Ref: ["abi" @ input.sol:18:5] -> built-in
+- Ref: ["encode" @ input.sol:18:9] -> built-in
+- Ref: ["abi" @ input.sol:19:6] -> built-in
+- Ref: ["encode" @ input.sol:19:11] -> built-in
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract TestBase {
+    │          ────┬───  
+    │              ╰───── name: 1
+  2 │   function g() public pure virtual returns (uint) {
+    │            ┬  
+    │            ╰── name: 2
+    │ 
+  7 │ contract Test is TestBase {
+    │          ──┬─    ────┬───  
+    │            ╰─────────────── name: 3
+    │                      │     
+    │                      ╰───── ref: 1
+  8 │   function g() public pure override returns (uint) {
+    │            ┬  
+    │            ╰── name: 4
+    │ 
+ 12 │   function parenthesised() public pure {
+    │            ──────┬──────  
+    │                  ╰──────── name: 5
+    │ 
+ 15 │     super.g();
+    │           ┬  
+    │           ╰── ref: 2
+ 16 │     (super).g();
+    │             ┬  
+    │             ╰── ref: 2
+    │ 
+ 18 │     abi.encode(uint(1));
+    │     ─┬─ ───┬──  
+    │      ╰────────── built-in
+    │            │    
+    │            ╰──── built-in
+ 19 │     (abi).encode(uint(1));
+    │      ─┬─  ───┬──  
+    │       ╰─────────── built-in
+    │              │    
+    │              ╰──── built-in
+────╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/expressions/parenthesised_operand/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/expressions/parenthesised_operand/input.sol
@@ -1,0 +1,21 @@
+contract TestBase {
+  function g() public pure virtual returns (uint) {
+    return 1;
+  }
+}
+
+contract Test is TestBase {
+  function g() public pure override returns (uint) {
+    return 2;
+  }
+
+  function parenthesised() public pure {
+    // Parentheses are transparent, so each pair below resolves identically:
+    // the parenthesised operand keeps the typing of the expression it wraps.
+    super.g();
+    (super).g();
+
+    abi.encode(uint(1));
+    (abi).encode(uint(1));
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/ambiguous_reference/overloaded_call_parenthesised/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/ambiguous_reference/overloaded_call_parenthesised/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/ambiguous-reference] Error: No unique declaration found for 'f'.
+    ╭─[input.sol:23:17]
+    │
+ 23 │         return (f)(300);
+    │                 ┬  
+    │                 ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/ambiguous_reference/overloaded_call_parenthesised/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/ambiguous_reference/overloaded_call_parenthesised/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2144] Error: No matching declaration found after variable lookup.
+    ╭─[input.sol:23:17]
+    │
+ 23 │         return (f)(300);
+    │                 ┬  
+    │                 ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/ambiguous_reference/overloaded_call_parenthesised/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/ambiguous_reference/overloaded_call_parenthesised/input.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    function f(uint8 a) internal pure returns (uint) {
+        return a;
+    }
+
+    function f(uint256 a) internal pure returns (uint) {
+        return 2 * a;
+    }
+
+    function g(uint256 a) internal pure returns (uint) {
+        return a;
+    }
+
+    function ambiguous() internal pure returns (uint) {
+        // Parentheses pass the typing of what they wrap straight through, but
+        // an overload set is not a typing a value position accepts: it is
+        // reported and sunk where the parentheses are. So the enclosing call
+        // has nothing left to narrow down, even though `300` selects a unique
+        // overload of the unwrapped `f(300)`.
+        return (f)(300);
+    }
+
+    function unambiguous() internal pure returns (uint) {
+        // A single declaration passes through untouched.
+        return (g)(300);
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:9:31]
+   │
+ 9 │     uint[2] memory flagged = [abi, tx];
+   │                               ─┬─  
+   │                                ╰─── Error occurred here.
+───╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:9:36]
+   │
+ 9 │     uint[2] memory flagged = [abi, tx];
+   │                                    ─┬  
+   │                                     ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 6378] Error: Unable to deduce common type for array elements.
+   ╭─[input.sol:9:30]
+   │
+ 9 │     uint[2] memory flagged = [abi, tx];
+   │                              ────┬────  
+   │                                  ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/generated/solc/0.8.21-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/generated/solc/0.8.21-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9563] Error: Invalid mobile type.
+   ╭─[input.sol:9:31]
+   │
+ 9 │     uint[2] memory flagged = [abi, tx];
+   │                               ─┬─  
+   │                                ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/array_literal_item/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: every item of an array literal is a value position, and each one
+// is reported rather than only the first.
+
+contract Test {
+  function f() public view {
+    uint[2] memory flagged = [abi, tx];
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/base_constructor_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/base_constructor_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:12:22]
+    │
+ 12 │   constructor() Base(abi) {}
+    │                      ─┬─  
+    │                       ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/base_constructor_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/base_constructor_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4649] Error: Invalid type for argument in modifier invocation. Invalid implicit conversion from abi to uint256 requested.
+    ╭─[input.sol:12:22]
+    │
+ 12 │   constructor() Base(abi) {}
+    │                      ─┬─  
+    │                       ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/base_constructor_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/base_constructor_argument/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a base constructor's arguments are values, given here on the
+// constructor rather than on the contract.
+
+contract Base {
+  constructor(uint value) {}
+}
+
+contract Test is Base {
+  constructor() Base(abi) {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_function/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_function/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:8:23]
+   │
+ 8 │     bytes32 flagged = keccak256;
+   │                       ────┬────  
+   │                           ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_function/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_function/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9574] Error: Type function (bytes memory) pure returns (bytes32) is not implicitly convertible to expected type bytes32.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     bytes32 flagged = keccak256;
+   │     ─────────────┬─────────────  
+   │                  ╰─────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_function/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a built-in function has no value of its own to assign.
+
+contract Test {
+  function f() public pure {
+    bytes32 flagged = keccak256;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_namespace/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_namespace/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:8:20]
+   │
+ 8 │     uint flagged = abi;
+   │                    ─┬─  
+   │                     ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_namespace/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_namespace/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9574] Error: Type abi is not implicitly convertible to expected type uint256.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     uint flagged = abi;
+   │     ─────────┬────────  
+   │              ╰────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_namespace/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_namespace/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: `abi` is a namespace, so it has no value to assign.
+
+contract Test {
+  function f() public pure {
+    uint flagged = abi;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:10:10]
+    │
+ 10 │     take(msg);
+    │          ─┬─  
+    │           ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9553] Error: Invalid type for argument in function call. Invalid implicit conversion from msg to uint256 requested.
+    ╭─[input.sol:10:10]
+    │
+ 10 │     take(msg);
+    │          ─┬─  
+    │           ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_argument/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: an argument is a value position, and `msg` is a namespace.
+
+contract Test {
+  function take(uint) internal pure {}
+
+  function f() public view {
+    take(msg);
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_option_value/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_option_value/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:12:21]
+    │
+ 12 │     target.g{value: abi}();
+    │                     ─┬─  
+    │                      ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_option_value/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_option_value/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7407] Error: Type abi is not implicitly convertible to expected type uint256.
+    ╭─[input.sol:12:21]
+    │
+ 12 │     target.g{value: abi}();
+    │                     ─┬─  
+    │                      ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_option_value/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/call_option_value/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a call option is passed to the call, so it is a value.
+
+interface Target {
+  function g() external payable;
+}
+
+contract Test {
+  function f(Target target) public {
+    target.g{value: abi}();
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/condition/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/condition/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:8:9]
+   │
+ 8 │     if (block) {}
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/condition/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/condition/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7407] Error: Type block is not implicitly convertible to expected type bool.
+   ╭─[input.sol:8:9]
+   │
+ 8 │     if (block) {}
+   │         ──┬──  
+   │           ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/condition/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/condition/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a condition is a value position, and `block` is a namespace.
+
+contract Test {
+  function f() public view {
+    if (block) {}
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/conditional_elementary_type_name_branches/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/conditional_elementary_type_name_branches/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 2
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
    ╭─[input.sol:6:16]
    │
  6 │     return c ? uint : uint;
@@ -10,7 +10,7 @@ Diagnostics: 2
    │                  ╰─── Error occurred here.
 ───╯
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
    ╭─[input.sol:6:23]
    │
  6 │     return c ? uint : uint;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/conditional_tuple_of_type_names/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/conditional_tuple_of_type_names/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 2
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
    ╭─[input.sol:7:16]
    │
  7 │     return c ? (uint, bool) : (uint, bool);
@@ -10,7 +10,7 @@ Diagnostics: 2
    │                      ╰─────── Error occurred here.
 ───╯
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
    ╭─[input.sol:7:31]
    │
  7 │     return c ? (uint, bool) : (uint, bool);

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/conditional_type_name_branch/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/conditional_type_name_branch/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 4
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
    ╭─[input.sol:8:16]
    │
  8 │     return c ? E : E.A;
@@ -10,7 +10,7 @@ Diagnostics: 4
    │                ╰── Error occurred here.
 ───╯
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
     ╭─[input.sol:13:27]
     │
  13 │     return c ? uint8(1) : E;
@@ -18,7 +18,7 @@ Diagnostics: 4
     │                           ╰── Error occurred here.
 ────╯
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
     ╭─[input.sol:19:16]
     │
  19 │     return c ? E : E;
@@ -26,7 +26,7 @@ Diagnostics: 4
     │                ╰── Error occurred here.
 ────╯
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
     ╭─[input.sol:19:20]
     │
  19 │     return c ? E : E;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/constant_initializer/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/constant_initializer/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:7:30]
+   │
+ 7 │ uint constant FLAGGED_FILE = abi;
+   │                              ─┬─  
+   │                               ╰─── Error occurred here.
+───╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:10:34]
+    │
+ 10 │   uint constant FLAGGED_MEMBER = tx;
+    │                                  ─┬  
+    │                                   ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/constant_initializer/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/constant_initializer/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[TypeError 7407] Error: Type abi is not implicitly convertible to expected type uint256.
+   ╭─[input.sol:7:30]
+   │
+ 7 │ uint constant FLAGGED_FILE = abi;
+   │                              ─┬─  
+   │                               ╰─── Error occurred here.
+───╯
+
+[TypeError 8349] Error: Initial value for constant variable has to be compile-time constant.
+   ╭─[input.sol:7:30]
+   │
+ 7 │ uint constant FLAGGED_FILE = abi;
+   │                              ─┬─  
+   │                               ╰─── Error occurred here.
+───╯
+
+[TypeError 7407] Error: Type tx is not implicitly convertible to expected type uint256.
+    ╭─[input.sol:10:34]
+    │
+ 10 │   uint constant FLAGGED_MEMBER = tx;
+    │                                  ─┬  
+    │                                   ╰── Error occurred here.
+────╯
+
+[TypeError 8349] Error: Initial value for constant variable has to be compile-time constant.
+    ╭─[input.sol:10:34]
+    │
+ 10 │   uint constant FLAGGED_MEMBER = tx;
+    │                                  ─┬  
+    │                                   ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/constant_initializer/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/constant_initializer/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a constant's initialiser is a value position, at file level and
+// inside a contract alike.
+
+uint constant FLAGGED_FILE = abi;
+
+contract Test {
+  uint constant FLAGGED_MEMBER = tx;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/emit_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/emit_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:10:18]
+    │
+ 10 │     emit Flagged(abi);
+    │                  ─┬─  
+    │                   ╰─── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:14:26]
+    │
+ 14 │     emit Flagged({value: tx});
+    │                          ─┬  
+    │                           ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/emit_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/emit_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 9553] Error: Invalid type for argument in function call. Invalid implicit conversion from abi to uint256 requested.
+    ╭─[input.sol:10:18]
+    │
+ 10 │     emit Flagged(abi);
+    │                  ─┬─  
+    │                   ╰─── Error occurred here.
+────╯
+
+[TypeError 9553] Error: Invalid type for argument in function call. Invalid implicit conversion from tx to uint256 requested.
+    ╭─[input.sol:14:26]
+    │
+ 14 │     emit Flagged({value: tx});
+    │                          ─┬  
+    │                           ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/emit_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/emit_argument/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: an event's arguments are values, positional or named.
+
+contract Test {
+  event Flagged(uint value);
+
+  function f() public {
+    emit Flagged(abi);
+  }
+
+  function g() public {
+    emit Flagged({value: tx});
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/index_access_index/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/index_access_index/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:11:10]
+    │
+ 11 │     data[abi];
+    │          ─┬─  
+    │           ╰─── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:12:11]
+    │
+ 12 │     input[tx:];
+    │           ─┬  
+    │            ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/index_access_index/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/index_access_index/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7407] Error: Type abi is not implicitly convertible to expected type uint256.
+    ╭─[input.sol:11:10]
+    │
+ 11 │     data[abi];
+    │          ─┬─  
+    │           ╰─── Error occurred here.
+────╯
+
+[TypeError 7407] Error: Type tx is not implicitly convertible to expected type uint256.
+    ╭─[input.sol:12:11]
+    │
+ 12 │     input[tx:];
+    │           ─┬  
+    │            ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/index_access_index/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/index_access_index/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: an index is a value position, as are a slice's bounds. The
+// indexed operand is a statement here, which the index does not become.
+
+contract Test {
+  uint[] data;
+
+  function f(bytes calldata input) public view {
+    data[abi];
+    input[tx:];
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/inheritance_specifier_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/inheritance_specifier_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:11:23]
+    │
+ 11 │ contract Test is Base(abi) {}
+    │                       ─┬─  
+    │                        ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/inheritance_specifier_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/inheritance_specifier_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9827] Error: Invalid type for argument in constructor call. Invalid implicit conversion from abi to uint256 requested.
+    ╭─[input.sol:11:23]
+    │
+ 11 │ contract Test is Base(abi) {}
+    │                       ─┬─  
+    │                        ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/inheritance_specifier_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/inheritance_specifier_argument/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: the arguments of a base contract are its constructor's, so they
+// are values.
+
+contract Base {
+  constructor(uint value) {}
+}
+
+contract Test is Base(abi) {}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:8:23]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │                       ─┬─  
+   │                        ╰─── Error occurred here.
+───╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:8:30]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │                              ─┬  
+   │                               ╰── Error occurred here.
+───╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:9:22]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │                      ──┬──  
+   │                        ╰──── Error occurred here.
+───╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:9:31]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │                               ─┬─  
+   │                                ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[TypeError 2271] Error: Operator && not compatible with types abi and tx
+   ╭─[input.sol:8:23]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │                       ────┬────  
+   │                           ╰────── Error occurred here.
+───╯
+
+[TypeError 9574] Error: Type abi is not implicitly convertible to expected type bool.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │     ─────────────┬─────────────  
+   │                  ╰─────────────── Error occurred here.
+───╯
+
+[TypeError 2271] Error: Operator || not compatible with types block and msg
+   ╭─[input.sol:9:22]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │                      ──────┬─────  
+   │                            ╰─────── Error occurred here.
+───╯
+
+[TypeError 9574] Error: Type block is not implicitly convertible to expected type bool.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/solc/0.8.16-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/solc/0.8.16-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[TypeError 2271] Error: Operator && not compatible with types abi and tx.
+   ╭─[input.sol:8:23]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │                       ────┬────  
+   │                           ╰────── Error occurred here.
+───╯
+
+[TypeError 9574] Error: Type abi is not implicitly convertible to expected type bool.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │     ─────────────┬─────────────  
+   │                  ╰─────────────── Error occurred here.
+───╯
+
+[TypeError 2271] Error: Operator || not compatible with types block and msg.
+   ╭─[input.sol:9:22]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │                      ──────┬─────  
+   │                            ╰─────── Error occurred here.
+───╯
+
+[TypeError 9574] Error: Type block is not implicitly convertible to expected type bool.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,35 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 4
+
+[TypeError 2271] Error: Built-in binary operator && cannot be applied to types abi and tx.
+   ╭─[input.sol:8:23]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │                       ────┬────  
+   │                           ╰────── Error occurred here.
+───╯
+
+[TypeError 9574] Error: Type abi is not implicitly convertible to expected type bool.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     bool flaggedAnd = abi && tx;
+   │     ─────────────┬─────────────  
+   │                  ╰─────────────── Error occurred here.
+───╯
+
+[TypeError 2271] Error: Built-in binary operator || cannot be applied to types block and msg.
+   ╭─[input.sol:9:22]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │                      ──────┬─────  
+   │                            ╰─────── Error occurred here.
+───╯
+
+[TypeError 9574] Error: Type block is not implicitly convertible to expected type bool.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     bool flaggedOr = block || msg;
+   │     ──────────────┬──────────────  
+   │                   ╰──────────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/logical_operator_operand/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: both operands of `&&` and `||` are value positions.
+
+contract Test {
+  function f() public view {
+    bool flaggedAnd = abi && tx;
+    bool flaggedOr = block || msg;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/loop_condition/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/loop_condition/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:11:12]
+    │
+ 11 │     while (abi) {}
+    │            ─┬─  
+    │             ╰─── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:12:18]
+    │
+ 12 │     do {} while (tx);
+    │                  ─┬  
+    │                   ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/loop_condition/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/loop_condition/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7407] Error: Type abi is not implicitly convertible to expected type bool.
+    ╭─[input.sol:11:12]
+    │
+ 11 │     while (abi) {}
+    │            ─┬─  
+    │             ╰─── Error occurred here.
+────╯
+
+[TypeError 7407] Error: Type tx is not implicitly convertible to expected type bool.
+    ╭─[input.sol:12:18]
+    │
+ 12 │     do {} while (tx);
+    │                  ─┬  
+    │                   ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/loop_condition/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/loop_condition/input.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a loop's condition is a value position.
+//
+// A `for` loop's condition is written as an expression statement, so it is not
+// checked yet and is left out here. See the TODO in `leave_for_statement`.
+
+contract Test {
+  function f() public view {
+    while (abi) {}
+    do {} while (tx);
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_invocation_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_invocation_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:11:30]
+    │
+ 11 │   function f() public view m(abi) {}
+    │                              ─┬─  
+    │                               ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_invocation_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_invocation_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 4649] Error: Invalid type for argument in modifier invocation. Invalid implicit conversion from abi to uint256 requested.
+    ╭─[input.sol:11:30]
+    │
+ 11 │   function f() public view m(abi) {}
+    │                              ─┬─  
+    │                               ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_invocation_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_invocation_argument/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a modifier's arguments are values.
+
+contract Test {
+  modifier m(uint value) {
+    _;
+  }
+
+  function f() public view m(abi) {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_placeholder/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_placeholder/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_placeholder/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_placeholder/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_placeholder/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/modifier_placeholder/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `_` is the modifier body placeholder, a statement not a value.
+
+contract Test {
+  modifier m() {
+    _;
+  }
+
+  function f() public m {}
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/module_aliases/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/module_aliases/generated/slang/0.8.0-failure.txt
@@ -2,7 +2,7 @@
 
 Diagnostics: 2
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
     ╭─[main.sol:11:20]
     │
  11 │     return (true ? A : B).K;
@@ -10,7 +10,7 @@ Diagnostics: 2
     │                    ╰── Error occurred here.
 ────╯
 
-[type-system/expression-not-a-value] Error: This expression denotes a type or declaration, not a value.
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
     ╭─[main.sol:11:24]
     │
  11 │     return (true ? A : B).K;

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/named_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/named_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:11:18]
+    │
+ 11 │     take({value: abi});
+    │                  ─┬─  
+    │                   ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/named_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/named_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9553] Error: Invalid type for argument in function call. Invalid implicit conversion from abi to uint256 requested.
+    ╭─[input.sol:11:18]
+    │
+ 11 │     take({value: abi});
+    │                  ─┬─  
+    │                   ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/named_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/named_argument/input.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a named argument's value is a value position, even where the
+// callee is a single declaration that no overload set has to select from.
+
+contract Test {
+  function take(uint value) internal pure {}
+
+  function f() public view {
+    take({value: abi});
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:8:24]
+   │
+ 8 │     uint flagged = 1 + tx;
+   │                        ─┬  
+   │                         ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2271] Error: Operator + not compatible with types int_const 1 and tx
+   ╭─[input.sol:8:20]
+   │
+ 8 │     uint flagged = 1 + tx;
+   │                    ───┬──  
+   │                       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/solc/0.8.16-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/solc/0.8.16-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2271] Error: Operator + not compatible with types int_const 1 and tx.
+   ╭─[input.sol:8:20]
+   │
+ 8 │     uint flagged = 1 + tx;
+   │                    ───┬──  
+   │                       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 2271] Error: Built-in binary operator + cannot be applied to types int_const 1 and tx.
+   ╭─[input.sol:8:20]
+   │
+ 8 │     uint flagged = 1 + tx;
+   │                    ───┬──  
+   │                       ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/operator_operand/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: an operand is a value position, and `tx` is a namespace.
+
+contract Test {
+  function f() public view {
+    uint flagged = 1 + tx;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,43 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 5
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.4'.
+   ╭─[input.sol:6:1]
+   │
+ 6 │ error Flagged(uint value);
+   │ ─────────────┬────────────  
+   │              ╰────────────── Error occurred here.
+───╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.4'.
+    ╭─[input.sol:10:5]
+    │
+ 10 │     revert Flagged(abi);
+    │     ──────────┬─────────  
+    │               ╰─────────── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:10:20]
+    │
+ 10 │     revert Flagged(abi);
+    │                    ─┬─  
+    │                     ╰─── Error occurred here.
+────╯
+
+[syntax/incompatible-syntax-version] Error: This syntax was introduced in version '0.8.4'.
+    ╭─[input.sol:14:5]
+    │
+ 14 │     revert Flagged({value: tx});
+    │     ──────────────┬─────────────  
+    │                   ╰─────────────── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:14:28]
+    │
+ 14 │     revert Flagged({value: tx});
+    │                            ─┬  
+    │                             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/slang/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/slang/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:10:20]
+    │
+ 10 │     revert Flagged(abi);
+    │                    ─┬─  
+    │                     ╰─── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:14:28]
+    │
+ 14 │     revert Flagged({value: tx});
+    │                            ─┬  
+    │                             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected ';' but got '('
+   ╭─[input.sol:6:14]
+   │
+ 6 │ error Flagged(uint value);
+   │              ┬  
+   │              ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/solc/0.8.4-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/generated/solc/0.8.4-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 9553] Error: Invalid type for argument in function call. Invalid implicit conversion from abi to uint256 requested.
+    ╭─[input.sol:10:20]
+    │
+ 10 │     revert Flagged(abi);
+    │                    ─┬─  
+    │                     ╰─── Error occurred here.
+────╯
+
+[TypeError 9553] Error: Invalid type for argument in function call. Invalid implicit conversion from tx to uint256 requested.
+    ╭─[input.sol:14:28]
+    │
+ 14 │     revert Flagged({value: tx});
+    │                            ─┬  
+    │                             ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/revert_argument/input.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: an error's arguments are values, positional or named.
+
+error Flagged(uint value);
+
+contract Test {
+  function f() public view {
+    revert Flagged(abi);
+  }
+
+  function g() public view {
+    revert Flagged({value: tx});
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/state_variable_initializer/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/state_variable_initializer/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:7:18]
+   │
+ 7 │   uint flagged = abi;
+   │                  ─┬─  
+   │                   ╰─── Error occurred here.
+───╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+   ╭─[input.sol:8:37]
+   │
+ 8 │   uint immutable flaggedImmutable = tx;
+   │                                     ─┬  
+   │                                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/state_variable_initializer/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/state_variable_initializer/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 7407] Error: Type abi is not implicitly convertible to expected type uint256.
+   ╭─[input.sol:7:18]
+   │
+ 7 │   uint flagged = abi;
+   │                  ─┬─  
+   │                   ╰─── Error occurred here.
+───╯
+
+[TypeError 7407] Error: Type tx is not implicitly convertible to expected type uint256.
+   ╭─[input.sol:8:37]
+   │
+ 8 │   uint immutable flaggedImmutable = tx;
+   │                                     ─┬  
+   │                                      ╰── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/state_variable_initializer/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/state_variable_initializer/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: a state variable's initialiser is a value position.
+
+contract Test {
+  uint flagged = abi;
+  uint immutable flaggedImmutable = tx;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/generated/solc/0.8.31-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/generated/solc/0.8.31-success.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 9207] Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+    ╭─[input.sol:10:5]
+    │
+ 10 │     payable(this).transfer;
+    │     ───────────┬──────────  
+    │                ╰──────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_address_transfer/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `payable(this).transfer` is inert here; the call is what transfers.
+
+contract Test {
+  receive() external payable {}
+
+  function f() public view {
+    payable(this).transfer;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/generated/solc/0.8.0-success.txt
@@ -1,13 +1,3 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Diagnostics: 1
-
-[Warning 2018] Warning: Function state mutability can be restricted to view
-    ╭─[input.sol:9:3]
-    │
-  9 │ ╭─▶   function f() public {
-    ┆ ┆   
- 11 │ ├─▶   }
-    │ │         
-    │ ╰───────── Error occurred here.
-────╯
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/generated/solc/0.8.0-success.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 2018] Warning: Function state mutability can be restricted to view
+    ╭─[input.sol:9:3]
+    │
+  9 │ ╭─▶   function f() public {
+    ┆ ┆   
+ 11 │ ├─▶   }
+    │ │         
+    │ ╰───────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/input.sol
@@ -6,7 +6,7 @@ pragma solidity *;
 contract Test {
   uint[] data;
 
-  function f() public {
+  function f() public view {
     data.pop;
   }
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_array_pop/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `data.pop` is inert here; the call is what pops.
+
+contract Test {
+  uint[] data;
+
+  function f() public {
+    data.pop;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_function/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_function/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_function/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_function/generated/solc/0.8.0-success.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 6133] Warning: Statement has no effect.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     keccak256;
+   │     ────┬────  
+   │         ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_function/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_function/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `keccak256` as a statement expression is inert.
+
+contract Test {
+  function f() public pure {
+    keccak256;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_member/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_member/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_member/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_member/generated/solc/0.8.0-success.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 6133] Warning: Statement has no effect.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     abi.encode;
+   │     ─────┬────  
+   │          ╰────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_member/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_member/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `abi.encode` as a statement expression is inert.
+
+contract Test {
+  function f() public pure {
+    abi.encode;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/generated/solc/0.8.0-success.txt
@@ -1,13 +1,3 @@
 # This file is generated automatically by infrastructure scripts. Please don't edit by hand.
 
-Diagnostics: 1
-
-[Warning 2018] Warning: Function state mutability can be restricted to pure
-   ╭─[input.sol:7:3]
-   │
- 7 │ ╭─▶   function f() public view {
-   ┆ ┆   
- 9 │ ├─▶   }
-   │ │         
-   │ ╰───────── Error occurred here.
-───╯
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/generated/solc/0.8.0-success.txt
@@ -1,0 +1,13 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 2018] Warning: Function state mutability can be restricted to pure
+   ╭─[input.sol:7:3]
+   │
+ 7 │ ╭─▶   function f() public view {
+   ┆ ┆   
+ 9 │ ├─▶   }
+   │ │         
+   │ ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `abi` as a statement expression is inert.
+
+contract Test {
+  function f() public view {
+    abi;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_built_in_namespace/input.sol
@@ -4,7 +4,7 @@ pragma solidity *;
 // Accepted: `abi` as a statement expression is inert.
 
 contract Test {
-  function f() public view {
+  function f() public pure {
     abi;
   }
 }

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_for_iterator/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_for_iterator/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_for_iterator/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_for_iterator/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_for_iterator/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_for_iterator/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: a `for` loop's iterator is a statement, so naming a built-in
+// there is inert, just as in an expression statement.
+
+contract Test {
+  function f() public pure {
+    for (uint i = 0; i < 3; abi) {
+    }
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_super/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_super/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_super/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_super/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_super/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/statement_super/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `super` as a statement expression is inert.
+
+contract Test {
+  function f() public pure {
+    super;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/super_reference/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/super_reference/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: 'super' cannot be used as a value.
+   ╭─[input.sol:8:20]
+   │
+ 8 │     uint flagged = super;
+   │                    ──┬──  
+   │                      ╰──── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/super_reference/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/super_reference/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9574] Error: Type type(contract super Test) is not implicitly convertible to expected type uint256.
+   ╭─[input.sol:8:5]
+   │
+ 8 │     uint flagged = super;
+   │     ──────────┬─────────  
+   │               ╰─────────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/super_reference/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/super_reference/input.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: `super` has no value by itself.
+
+contract Test {
+  function f() public pure {
+    uint flagged = super;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/tuple_component/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/tuple_component/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:10:22]
+    │
+ 10 │     (left, right) = (abi, tx);
+    │                      ─┬─  
+    │                       ╰─── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This built-in cannot be used as a value.
+    ╭─[input.sol:10:27]
+    │
+ 10 │     (left, right) = (abi, tx);
+    │                           ─┬  
+    │                            ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/tuple_component/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/tuple_component/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 7407] Error: Type tuple(abi,tx) is not implicitly convertible to expected type tuple(uint256,bool).
+    ╭─[input.sol:10:21]
+    │
+ 10 │     (left, right) = (abi, tx);
+    │                     ────┬────  
+    │                         ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/tuple_component/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/tuple_component/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: every component of a multi-component tuple is a value position.
+
+contract Test {
+  function f() public view {
+    uint left;
+    bool right;
+    (left, right) = (abi, tx);
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/uncalled_new/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/uncalled_new/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: An uncalled 'new' expression cannot be used as a value.
+    ╭─[input.sol:10:21]
+    │
+ 10 │     Other flagged = new Other;
+    │                     ────┬────  
+    │                         ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/uncalled_new/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/uncalled_new/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9574] Error: Type function () returns (contract Other) is not implicitly convertible to expected type contract Other.
+    ╭─[input.sol:10:5]
+    │
+ 10 │     Other flagged = new Other;
+    │     ────────────┬────────────  
+    │                 ╰────────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/uncalled_new/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/uncalled_new/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: `new Other` is not a value until it is called.
+
+contract Other {}
+
+contract Test {
+  function f() public {
+    Other flagged = new Other;
+  }
+}


### PR DESCRIPTION
Builds on top of #2067 

Adds `type-system/expression-not-a-value`, reported when an expression in a value position names something that has no value of its own: a built-in (a namespace such as `abi`, or a built-in function), `super`, or a `new` that is never called.

This new diagnostic does not match any solc error code 1:1 because they don't narrow typing in the same way slang does. It's ground work to allow easily adding many conversion checks that span about 15 solc error codes.

Value positions go through one check and `p5_resolve_references` gains a three-step ladder, replacing the previous callee/non-callee pair:

- `raw_typing_of_expression` looks up the registered typing and checks nothing, so a callee can still select from an overload set;
- `check_typing_of_expression` reports a set that nothing can select from and sinks it to unresolved;
- `check_type_of_value_expression` additionally rejects the typings that name something other than a value, and is where the new diagnostic is reported.

Every position requiring a value now routes through it, including several that did not type their operands at all before: the operands of `&&` and `||`, the index and slice bounds of an index access, `do while` conditions, modifier and base-constructor arguments, inheritance specifier arguments, call options, and state-variable and constant initialisers.

Statements deliberately do not require a value so `super;`, `data.pop;` and a modifier's `_` placeholder stay legal, as does a `for` loop's iterator, which Solidity writes as an expression statement. This follows what `solc` does, but we may want to revisit if it complicates codegen since it let's nonsense code through the pipeline which may choke the backend.

A parenthesised single-item tuple keeps propagating its operand's typing, so `(super).g()` and `(abi).encode()` resolve as the unwrapped forms do, while an overload set is still sunk there: `(f)(300)` is rejected even though `f(300)` selects a unique overload, matching solc.

Argument collection yields `Option<Vec<TypeId>>` and skips overload disambiguation when any argument has no type, since no candidate can accept it and reporting the call as having no candidate would only cascade over the argument's own failure.
