### PR TITLE
fix(semantic): Handle `fixed` and `ufixed` type parsing

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/types/parsing.rs
@@ -40,13 +40,8 @@ impl Type {
     }
 
     pub fn from_fixed_keyword(keyword: &str) -> Self {
-        let mut parts = keyword
-            .strip_prefix("fixed")
-            .unwrap()
-            .split('x')
-            .map(|part| part.parse::<u32>().unwrap());
-        let bits = parts.next().unwrap();
-        let decimal_places = parts.next().unwrap_or(0);
+        let (bits, decimal_places) =
+            parse_fixed_point_suffix(keyword.strip_prefix("fixed").unwrap());
         Self::FixedPointNumber(FixedPointNumberType {
             is_signed: true,
             bits,
@@ -55,17 +50,81 @@ impl Type {
     }
 
     pub fn from_ufixed_keyword(keyword: &str) -> Self {
-        let mut parts = keyword
-            .strip_prefix("ufixed")
-            .unwrap()
-            .split('x')
-            .map(|part| part.parse::<u32>().unwrap());
-        let bits = parts.next().unwrap();
-        let decimal_places = parts.next().unwrap_or(0);
+        let (bits, decimal_places) =
+            parse_fixed_point_suffix(keyword.strip_prefix("ufixed").unwrap());
         Self::FixedPointNumber(FixedPointNumberType {
             is_signed: false,
             bits,
             decimal_places,
         })
+    }
+}
+
+/// Bare `fixed`/`ufixed` (an empty suffix) is an alias for the `128x18` variant.
+const DEFAULT_FIXED_POINT_BITS: u32 = 128;
+const DEFAULT_FIXED_POINT_DECIMAL_PLACES: u32 = 18;
+
+/// Splits the `MxN` part of a `fixed`/`ufixed` keyword into bits and decimal places.
+fn parse_fixed_point_suffix(suffix: &str) -> (u32, u32) {
+    let Some((bits, decimal_places)) = suffix.split_once('x') else {
+        return (DEFAULT_FIXED_POINT_BITS, DEFAULT_FIXED_POINT_DECIMAL_PLACES);
+    };
+    (bits.parse().unwrap(), decimal_places.parse().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::{FixedPointNumberType, IntegerType, Type};
+
+    fn fixed_point(is_signed: bool, bits: u32, decimal_places: u32) -> Type {
+        Type::FixedPointNumber(FixedPointNumberType {
+            is_signed,
+            bits,
+            decimal_places,
+        })
+    }
+
+    #[test]
+    fn integer_keywords() {
+        assert_eq!(
+            Type::from_int_keyword("int"),
+            Type::Integer(IntegerType {
+                is_signed: true,
+                bits: 256
+            })
+        );
+        assert_eq!(
+            Type::from_uint_keyword("uint8"),
+            Type::Integer(IntegerType {
+                is_signed: false,
+                bits: 8
+            })
+        );
+    }
+
+    #[test]
+    fn fixed_point_keywords() {
+        // A bare keyword is an alias for the `128x18` variant.
+        assert_eq!(
+            Type::from_fixed_keyword("fixed"),
+            fixed_point(true, 128, 18)
+        );
+        assert_eq!(
+            Type::from_ufixed_keyword("ufixed"),
+            fixed_point(false, 128, 18)
+        );
+
+        assert_eq!(
+            Type::from_fixed_keyword("fixed128x18"),
+            Type::from_fixed_keyword("fixed")
+        );
+        assert_eq!(
+            Type::from_ufixed_keyword("ufixed8x0"),
+            fixed_point(false, 8, 0)
+        );
+        assert_eq!(
+            Type::from_fixed_keyword("fixed184x80"),
+            fixed_point(true, 184, 80)
+        );
     }
 }

--- a/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/binder_output/snapshots.generated.rs
@@ -1393,6 +1393,11 @@ mod variables {
     }
 
     #[test]
+    fn fixed_point_types() -> Result<()> {
+        run("variables", "fixed_point_types")
+    }
+
+    #[test]
     fn incomplete_type_name() -> Result<()> {
         run("variables", "incomplete_type_name")
     }

--- a/crates/solidity-v2/testing/snapshots/binder_output/variables/fixed_point_types/generated/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/binder_output/variables/fixed_point_types/generated/0.8.0-success.txt
@@ -1,0 +1,62 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Definitions (6):
+- Def: #1 ["Foo" @ input.sol:1:10] (contract)
+- Def: #2 ["bar" @ input.sol:2:14] (function, type: function () returns void)
+- Def: #3 ["a" @ input.sol:4:15] (variable, type: fixed128x18)
+- Def: #4 ["b" @ input.sol:5:16] (variable, type: ufixed128x18)
+- Def: #5 ["c" @ input.sol:6:21] (variable, type: fixed128x18)
+- Def: #6 ["d" @ input.sol:7:19] (variable, type: ufixed8x0)
+
+------------------------------------------------------------------------
+
+References (5):
+- Ref: ["a" @ input.sol:6:25] -> #3
+- Ref: ["a" @ input.sol:8:9] -> #3
+- Ref: ["b" @ input.sol:9:9] -> #4
+- Ref: ["c" @ input.sol:10:9] -> #5
+- Ref: ["d" @ input.sol:11:9] -> #6
+
+------------------------------------------------------------------------
+
+Unbound identifiers (0):
+
+------------------------------------------------------------------------
+
+Bindings: 
+    ╭─[input.sol:1:1]
+    │
+  1 │ contract Foo {
+    │          ─┬─  
+    │           ╰─── name: 1
+  2 │     function bar() public pure {
+    │              ─┬─  
+    │               ╰─── name: 2
+    │ 
+  4 │         fixed a = 0.5;
+    │               ┬  
+    │               ╰── name: 3
+  5 │         ufixed b = 0.5;
+    │                ┬  
+    │                ╰── name: 4
+  6 │         fixed128x18 c = a;
+    │                     ┬   ┬  
+    │                     ╰────── name: 5
+    │                         │  
+    │                         ╰── ref: 3
+  7 │         ufixed8x0 d = 1;
+    │                   ┬  
+    │                   ╰── name: 6
+  8 │         a;
+    │         ┬  
+    │         ╰── ref: 3
+  9 │         b;
+    │         ┬  
+    │         ╰── ref: 4
+ 10 │         c;
+    │         ┬  
+    │         ╰── ref: 5
+ 11 │         d;
+    │         ┬  
+    │         ╰── ref: 6
+────╯

--- a/crates/solidity-v2/testing/snapshots/binder_output/variables/fixed_point_types/input.sol
+++ b/crates/solidity-v2/testing/snapshots/binder_output/variables/fixed_point_types/input.sol
@@ -1,0 +1,13 @@
+contract Foo {
+    function bar() public pure {
+        // Bare 'fixed'/'ufixed' are aliases for the '128x18' variants.
+        fixed a = 0.5;
+        ufixed b = 0.5;
+        fixed128x18 c = a;
+        ufixed8x0 d = 1;
+        a;
+        b;
+        c;
+        d;
+    }
+}


### PR DESCRIPTION
Before this change, code would panic on an empty suffix. Handle the case and return the default bits and decimal places for `fixed` and `ufixed` (128x18).