### PR TITLE
fix(diagnostics): Handle solc errors reported on the whole file

### DIFF
--- a/crates/infra/utils/src/solc/json_cli.rs
+++ b/crates/infra/utils/src/solc/json_cli.rs
@@ -4,7 +4,8 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
 use strum::Display;
 
 #[derive(Debug, Serialize)]
@@ -60,10 +61,29 @@ pub struct Error {
 #[serde(rename_all = "camelCase")]
 pub struct SourceLocation {
     pub file: PathBuf,
-    /// 0-based character index
-    pub start: usize,
-    /// 0-based character index
-    pub end: usize,
+    /// 0-based character index, or `None` when the diagnostic refers to the
+    /// file as a whole rather than a span within it. Those are reported as
+    /// `-1`, e.g. the warning about a missing SPDX license identifier.
+    #[serde(deserialize_with = "deserialize_offset")]
+    pub start: Option<usize>,
+    /// 0-based character index. See [`SourceLocation::start`].
+    #[serde(deserialize_with = "deserialize_offset")]
+    pub end: Option<usize>,
+}
+
+fn deserialize_offset<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<usize>, D::Error> {
+    // `-1` is the only negative offset with a meaning: the diagnostic refers to
+    // the whole file. Any other negative value is something we don't model.
+    match i64::deserialize(deserializer)? {
+        -1 => Ok(None),
+        offset => usize::try_from(offset).map(Some).map_err(|_| {
+            D::Error::custom(format!(
+                "unexpected negative source location offset: {offset}"
+            ))
+        }),
+    }
 }
 
 #[derive(Display, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/infra/utils/src/solc/render.rs
+++ b/crates/infra/utils/src/solc/render.rs
@@ -21,12 +21,16 @@ pub fn render_solc_error(error: &Error, sources: &BTreeMap<String, String>) -> R
     };
 
     let source_id = source_location.file.unwrap_string();
+
+    // Diagnostics about the file as a whole have no span to point at, so
+    // render just the header and the file name (matching `solc`'s own format).
+    let (Some(start), Some(end)) = (source_location.start, source_location.end) else {
+        return Ok(format!("[{code}] {kind}: {message}\n--> {source_id}"));
+    };
+
     let source = sources.get(&source_id).unwrap();
 
     let range = {
-        let start = source_location.start;
-        let end = source_location.end;
-
         let start_chars = source[..start].chars().count();
         let end_chars = start_chars + source[start..end].chars().count();
 

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1267,6 +1267,15 @@ mod resolution {
     }
 }
 
+mod runner {
+    use super::*;
+
+    #[test]
+    fn diagnostic_without_source_span() -> Result<()> {
+        run("runner", "diagnostic_without_source_span")
+    }
+}
+
 mod semantic {
     use super::*;
 

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/runner/diagnostic_without_source_span/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/runner/diagnostic_without_source_span/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/runner/diagnostic_without_source_span/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/runner/diagnostic_without_source_span/generated/solc/0.8.0-success.txt
@@ -1,0 +1,6 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[Warning 1878] Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+--> input.sol

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/runner/diagnostic_without_source_span/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/runner/diagnostic_without_source_span/input.sol
@@ -1,0 +1,8 @@
+pragma solidity *;
+
+// This input intentionally omits the license header that every other snapshot
+// input carries, because that is the simplest way to make solc report a
+// diagnostic about the file as a whole. Those carry no span to point at, and
+// the runner used to fail while reading them.
+
+contract C {}


### PR DESCRIPTION
For errors/warnings related to the whole file, eg. a missing SPDX license identifier, solc doesn't reports the span with `start` and `end` at -1 in the JSON, and that was choking the runner that expects both to be deserializable to `usize`.