### PR TITLE
perf(semantic): Avoid cloning `Typing` from nodes in most cases

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
+++ b/crates/solidity-v2/outputs/cargo/semantic/generated/public_api.txt
@@ -75,7 +75,7 @@ pub fn slang_solidity_v2_semantic::binder::Typing::fmt(&self, &mut core::fmt::Fo
 pub struct slang_solidity_v2_semantic::binder::Binder
 impl slang_solidity_v2_semantic::binder::Binder
 pub fn slang_solidity_v2_semantic::binder::Binder::assembly_block_referenced_definitions(&self, slang_solidity_v2_common::nodes::NodeId) -> &[slang_solidity_v2_common::nodes::NodeId]
-pub fn slang_solidity_v2_semantic::binder::Binder::common_operand_typing(&self, slang_solidity_v2_common::nodes::NodeId) -> slang_solidity_v2_semantic::binder::Typing
+pub fn slang_solidity_v2_semantic::binder::Binder::common_operand_typing(&self, slang_solidity_v2_common::nodes::NodeId) -> &slang_solidity_v2_semantic::binder::Typing
 pub fn slang_solidity_v2_semantic::binder::Binder::definitions(&self) -> &slang_solidity_v2_common::collections::aliases::Map<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Definition>
 pub fn slang_solidity_v2_semantic::binder::Binder::enclosing_definition_node_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 pub fn slang_solidity_v2_semantic::binder::Binder::find_definition_by_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_semantic::binder::Definition>
@@ -83,7 +83,7 @@ pub fn slang_solidity_v2_semantic::binder::Binder::find_definition_by_identifier
 pub fn slang_solidity_v2_semantic::binder::Binder::find_reference_by_identifier_node_id(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&slang_solidity_v2_semantic::binder::Reference>
 pub fn slang_solidity_v2_semantic::binder::Binder::get_linearised_bases(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<&alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>>
 pub fn slang_solidity_v2_semantic::binder::Binder::get_references_by_definition_id(&self, slang_solidity_v2_common::nodes::NodeId) -> alloc::vec::Vec<slang_solidity_v2_common::nodes::NodeId>
-pub fn slang_solidity_v2_semantic::binder::Binder::node_typing(&self, slang_solidity_v2_common::nodes::NodeId) -> slang_solidity_v2_semantic::binder::Typing
+pub fn slang_solidity_v2_semantic::binder::Binder::node_typing(&self, slang_solidity_v2_common::nodes::NodeId) -> &slang_solidity_v2_semantic::binder::Typing
 pub fn slang_solidity_v2_semantic::binder::Binder::references(&self) -> &slang_solidity_v2_common::collections::aliases::Map<slang_solidity_v2_common::nodes::NodeId, slang_solidity_v2_semantic::binder::Reference>
 pub fn slang_solidity_v2_semantic::binder::Binder::resolved_operator_function(&self, slang_solidity_v2_common::nodes::NodeId) -> core::option::Option<slang_solidity_v2_common::nodes::NodeId>
 impl core::default::Default for slang_solidity_v2_semantic::binder::Binder

--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -73,6 +73,12 @@ pub enum Typing {
 }
 
 impl Typing {
+    /// Handed back by the typing lookups for a node that has none registered,
+    /// so they can borrow instead of building an owned `Typing` per miss. Also
+    /// serves a pass that sinks a typing to `Unresolved` while returning a
+    /// borrow.
+    pub(crate) const UNRESOLVED: Self = Self::Unresolved;
+
     /// Returns the resolved `TypeId`, if any.
     pub fn as_type_id(&self) -> Option<TypeId> {
         match self {
@@ -415,18 +421,21 @@ impl Binder {
         self.get_scope_by_id(scope_id).get_using_directives()
     }
 
-    pub fn node_typing(&self, node_id: NodeId) -> Typing {
+    /// The typing registered for `node_id`, borrowed: a `Typing` is 32 bytes
+    /// and owns a `Vec` when it holds an overload set, and this is looked up on
+    /// nearly every expression. Callers that need to keep one clone it.
+    pub fn node_typing(&self, node_id: NodeId) -> &Typing {
         self.node_typing
             .get(&node_id)
-            .cloned()
-            .unwrap_or(Typing::Unresolved)
+            .unwrap_or(&Typing::UNRESOLVED)
     }
 
-    pub fn common_operand_typing(&self, node_id: NodeId) -> Typing {
+    /// The common operand typing recorded for the comparison at `node_id`,
+    /// borrowed for the same reason as [`Self::node_typing`].
+    pub fn common_operand_typing(&self, node_id: NodeId) -> &Typing {
         self.common_operand_typing
             .get(&node_id)
-            .cloned()
-            .unwrap_or(Typing::Unresolved)
+            .unwrap_or(&Typing::UNRESOLVED)
     }
 
     pub(crate) fn set_node_type(&mut self, node_id: NodeId, type_id: Option<TypeId>) {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/common/resolution.rs
@@ -64,7 +64,7 @@ pub(crate) fn filter_overriden_definitions(
     for definition_id in definition_ids {
         match binder.find_definition_by_id(definition_id).unwrap() {
             Definition::Function(_) => {
-                if let Typing::Resolved(type_id) = binder.node_typing(definition_id) {
+                if let &Typing::Resolved(type_id) = binder.node_typing(definition_id) {
                     let Type::Function(function_type) = types.get_type_by_id(type_id) else {
                         unreachable!("type of function definition is not a function");
                     };

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/resolution.rs
@@ -216,7 +216,7 @@ impl Pass<'_> {
             return false;
         }
 
-        let Typing::Resolved(definition_type_id) = self.binder.node_typing(definition_id) else {
+        let &Typing::Resolved(definition_type_id) = self.binder.node_typing(definition_id) else {
             // definition type cannot be resolved
             return false;
         };
@@ -288,7 +288,7 @@ impl Pass<'_> {
         let Some(Definition::Function(_)) = self.binder.find_definition_by_id(definition_id) else {
             return false;
         };
-        let Typing::Resolved(definition_type_id) = self.binder.node_typing(definition_id) else {
+        let &Typing::Resolved(definition_type_id) = self.binder.node_typing(definition_id) else {
             return false;
         };
         let Type::Function(function_type) = self.types.get_type_by_id(definition_type_id) else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -1,4 +1,5 @@
 use ruint::aliases::{U160, U256};
+use slang_solidity_v2_common::diagnostics::DiagnosticCollection;
 use slang_solidity_v2_common::diagnostics::kinds::resolution::{
     AmbiguousReference, MemberNotFound, NoMatchingCallableDeclaration,
 };
@@ -13,8 +14,9 @@ use slang_solidity_v2_ir::ir::NodeIdentity;
 
 use super::Pass;
 use super::disambiguation::OverloadMatch;
-use crate::binder::{Definition, Resolution, Typing};
+use crate::binder::{Binder, Definition, Resolution, Typing};
 use crate::built_ins::BuiltInCallError;
+use crate::context::FileNodeMapper;
 use crate::passes::common::node_location;
 use crate::types::{
     AddressType, ArraySliceType, ArrayType, ContractType, DataLocation, ErrorType, EventType,
@@ -33,17 +35,24 @@ impl Pass<'_> {
         )
     }
 
-    /// The typing registered for `node`, checking nothing: an overload set is
-    /// handed on undetermined, so a callee can still select from it. This is a
-    /// plain lookup for the typing each expression registers during the pass.
-    #[inline]
-    pub(super) fn raw_typing_of_expression(&self, node: &ir::Expression) -> Typing {
+    /// The typing registered for `node`, borrowed out of `binder`. Takes the
+    /// binder alone rather than the whole pass, so that a caller which also
+    /// reports can hold this borrow and `diagnostics` at the same time.
+    fn typing_of_expression_in<'a>(binder: &'a Binder, node: &ir::Expression) -> &'a Typing {
         // Every expression variant registers its typing in the binder during
         // the pass, so we simply look it up by `NodeId`.
         let node_id = node
             .node_id()
             .expect("expression should have a NodeId to look up its typing");
-        self.binder.node_typing(node_id)
+        binder.node_typing(node_id)
+    }
+
+    /// The typing registered for `node`, checking nothing: an overload set is
+    /// handed on undetermined, so a callee can still select from it. This is a
+    /// plain lookup for the typing each expression registers during the pass.
+    #[inline]
+    pub(super) fn raw_typing_of_expression(&self, node: &ir::Expression) -> &Typing {
+        Self::typing_of_expression_in(self.binder, node)
     }
 
     /// The typing of `node` where nothing can select from an overload set, so
@@ -52,39 +61,46 @@ impl Pass<'_> {
     /// name something other than a value, so a position that requires one
     /// should use [`Self::check_type_of_value_expression`] instead.
     #[inline]
-    pub(super) fn check_typing_of_expression(&mut self, node: &ir::Expression) -> Typing {
-        match self.raw_typing_of_expression(node) {
-            Typing::Undetermined(_) => {
-                self.report_ambiguous_reference(node);
-                Typing::Unresolved
-            }
-            typing => typing,
+    pub(super) fn check_typing_of_expression(&mut self, node: &ir::Expression) -> &Typing {
+        // The returned typing is borrowed out of `binder` while reporting takes
+        // `diagnostics`, so both are reached as separate fields to keep the
+        // borrows disjoint. Going through `Self::raw_typing_of_expression`
+        // would borrow the whole pass instead, and conflict.
+        let typing = Self::typing_of_expression_in(self.binder, node);
+        if matches!(typing, Typing::Undetermined(_)) {
+            Self::report_ambiguous_reference(self.diagnostics, self.file_node_mapper, node);
+            return &Typing::UNRESOLVED;
         }
+        typing
     }
 
-    /// The type of `node` in a position that requires a value. On top of
-    /// [`Self::check_typing_of_expression`], the typings that name something
-    /// which is not a value have no type here: a built-in (a namespace such as
-    /// `abi`, or a built-in function), `super`, and an uncalled `new`.
+    /// The type of `node` in a position that requires a value. Reports the
+    /// overload set [`Self::check_typing_of_expression`] does, and on top of it
+    /// the typings that name something which is not a value: a built-in (a
+    /// namespace such as `abi`, or a built-in function), `super`, and an
+    /// uncalled `new`.
     #[inline]
     pub(super) fn check_type_of_value_expression(
         &mut self,
         node: &ir::Expression,
     ) -> Option<TypeId> {
-        match self.check_typing_of_expression(node) {
-            Typing::BuiltIn(_) => {
-                self.report_expression_not_a_value(node, NotAValueKind::BuiltIn);
+        // The typing is matched down to a `Copy` outcome first, which releases
+        // the borrow of `binder` it came from and lets the reporting below take
+        // the pass mutably.
+        let outcome = match self.check_typing_of_expression(node) {
+            Typing::Resolved(type_id) | Typing::This(type_id) => Ok(Some(*type_id)),
+            // An overload set has already been reported and sunk above.
+            Typing::Unresolved | Typing::Undetermined(_) => Ok(None),
+            Typing::BuiltIn(_) => Err(NotAValueKind::BuiltIn),
+            Typing::Super => Err(NotAValueKind::Super),
+            Typing::NewExpression(_) => Err(NotAValueKind::UncalledNew),
+        };
+        match outcome {
+            Ok(type_id) => type_id,
+            Err(kind) => {
+                self.report_expression_not_a_value(node, kind);
                 None
             }
-            Typing::Super => {
-                self.report_expression_not_a_value(node, NotAValueKind::Super);
-                None
-            }
-            Typing::NewExpression(_) => {
-                self.report_expression_not_a_value(node, NotAValueKind::UncalledNew);
-                None
-            }
-            typing => typing.as_type_id(),
         }
     }
 
@@ -146,7 +162,11 @@ impl Pass<'_> {
             }
             OverloadMatch::Unique(selected) => Some(selected),
             OverloadMatch::Ambiguous(selected) => {
-                self.report_ambiguous_identifier(identifier);
+                Self::report_ambiguous_identifier(
+                    self.diagnostics,
+                    self.file_node_mapper,
+                    identifier,
+                );
                 Some(selected)
             }
         }
@@ -166,7 +186,11 @@ impl Pass<'_> {
             }
             OverloadMatch::Unique(selected) => Some(selected),
             OverloadMatch::Ambiguous(selected) => {
-                self.report_ambiguous_identifier(identifier);
+                Self::report_ambiguous_identifier(
+                    self.diagnostics,
+                    self.file_node_mapper,
+                    identifier,
+                );
                 Some(selected)
             }
         }
@@ -176,19 +200,31 @@ impl Pass<'_> {
     /// Kept out of line so that reporting, which is rare, does not stop
     /// [`Self::check_typing_of_expression`] from inlining into its many
     /// callers.
+    ///
+    /// Takes the two fields it needs rather than the pass, so that a caller
+    /// holding a typing borrowed out of `binder` can still report.
     #[cold]
     #[inline(never)]
-    fn report_ambiguous_reference(&mut self, node: &ir::Expression) {
+    fn report_ambiguous_reference(
+        diagnostics: &mut DiagnosticCollection,
+        file_node_mapper: &FileNodeMapper,
+        node: &ir::Expression,
+    ) {
         if let Some(identifier) = reference_identifier_for_expression(node) {
-            self.report_ambiguous_identifier(identifier);
+            Self::report_ambiguous_identifier(diagnostics, file_node_mapper, identifier);
         }
     }
 
     /// The diagnostic is located at the identifier the reference was made
     /// through, which is also where its name comes from.
-    fn report_ambiguous_identifier(&mut self, identifier: &ir::Identifier) {
+    fn report_ambiguous_identifier(
+        diagnostics: &mut DiagnosticCollection,
+        file_node_mapper: &FileNodeMapper,
+        identifier: &ir::Identifier,
+    ) {
+        let (file_id, range) = node_location(identifier, file_node_mapper);
         let name = identifier.unparse().to_owned();
-        self.push_diagnostic(identifier, AmbiguousReference { name });
+        diagnostics.push(file_id, range, AmbiguousReference { name });
     }
 
     pub(super) fn type_of_elementary_type(elementary_type: &ir::ElementaryType) -> Type {
@@ -472,11 +508,13 @@ impl Pass<'_> {
         match resolution {
             Resolution::Unresolved => Typing::Unresolved,
             Resolution::BuiltIn(built_in) => self.built_ins_resolver().typing_of(built_in),
-            Resolution::Definition(definition_id) => self.binder.node_typing(*definition_id),
+            Resolution::Definition(definition_id) => {
+                self.binder.node_typing(*definition_id).clone()
+            }
             Resolution::Ambiguous(definitions) => {
                 let mut type_ids = Vec::new();
                 for definition_id in definitions {
-                    if let Typing::Resolved(type_id) = self.binder.node_typing(*definition_id) {
+                    if let &Typing::Resolved(type_id) = self.binder.node_typing(*definition_id) {
                         type_ids.push(type_id);
                     }
                 }
@@ -695,7 +733,7 @@ impl Pass<'_> {
         node: &ir::FunctionCallExpression,
         arguments: &[ir::Expression],
     ) -> Typing {
-        let operand_typing = self.raw_typing_of_expression(&node.operand);
+        let operand_typing = self.raw_typing_of_expression(&node.operand).clone();
         let argument_types = self.collect_positional_argument_types(arguments);
 
         match operand_typing {
@@ -928,7 +966,7 @@ impl Pass<'_> {
         node: &ir::FunctionCallExpression,
         arguments: &[ir::NamedArgument],
     ) -> Typing {
-        let operand_typing = self.raw_typing_of_expression(&node.operand);
+        let operand_typing = self.raw_typing_of_expression(&node.operand).clone();
         let argument_types = self.collect_named_argument_types(arguments);
 
         let (typing, definition_id) = match operand_typing {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -374,7 +374,7 @@ impl Visitor for Pass<'_> {
             // a value is required is for the enclosing context to decide, and
             // it sees this same typing.
             match &node.items.first().unwrap().expression {
-                Some(expression) => self.check_typing_of_expression(expression),
+                Some(expression) => self.check_typing_of_expression(expression).clone(),
                 None => Typing::Unresolved,
             }
         } else {
@@ -395,7 +395,7 @@ impl Visitor for Pass<'_> {
     fn leave_member_access_expression(&mut self, node: &ir::MemberAccessExpression) {
         // we need to resolve the identifier at this point that we already have
         // typing information of the operand expression
-        let operand_typing = self.check_typing_of_expression(&node.operand);
+        let operand_typing = self.check_typing_of_expression(&node.operand).clone();
         let member_resolution =
             self.resolve_symbol_in_typing(&operand_typing, node.member.unparse());
         let resolution = filter_overriden_definitions(self.binder, self.types, member_resolution);
@@ -613,7 +613,7 @@ impl Visitor for Pass<'_> {
 
         // `foo{value: 3}` partially applies but is still a callee, so an
         // overload set has to survive to the enclosing call.
-        let operand_typing = self.raw_typing_of_expression(&node.operand);
+        let operand_typing = self.raw_typing_of_expression(&node.operand).clone();
 
         // Pre-applying call options (eg. `foo{value: 3}`) partially applies the
         // function.

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_contract_properties/contract_dependencies/references.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p7_contract_properties/contract_dependencies/references.rs
@@ -83,7 +83,7 @@ fn new_expression_target(
     types: &TypeRegistry,
     node: &ir::NewExpression,
 ) -> Option<NodeId> {
-    let Typing::NewExpression(type_id) = binder.node_typing(node.id()) else {
+    let &Typing::NewExpression(type_id) = binder.node_typing(node.id()) else {
         return None;
     };
     // A library cannot be created, so only a contract is a target here.
@@ -108,7 +108,7 @@ fn code_access_target(
         return None;
     }
     let operand_id = node.operand.node_id()?;
-    let Typing::BuiltIn(InternalBuiltIn::Type(type_id)) = binder.node_typing(operand_id) else {
+    let &Typing::BuiltIn(InternalBuiltIn::Type(type_id)) = binder.node_typing(operand_id) else {
         return None;
     };
     // A library is deployed too, so its code can be read the same way.
@@ -284,7 +284,7 @@ impl ReferenceCollector<'_> {
                         node.id(),
                         definition_id,
                         &function.ir_node,
-                        &operand_typing,
+                        operand_typing,
                     );
                 }
                 // A constant's value is compiled into the referencing unit,

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/fallback_functions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/fallback_functions.rs
@@ -105,7 +105,7 @@ fn check_fallback_function(
     // The mutability and signature can be extracted from the function's type,
     // computed during type definition. A function definition always types to a
     // function type.
-    let Typing::Resolved(type_id) = binder.node_typing(node.id()) else {
+    let &Typing::Resolved(type_id) = binder.node_typing(node.id()) else {
         unreachable!("fallback function definition is not typed");
     };
     let Type::Function(function_type) = types.get_type_by_id(type_id) else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/receive_functions.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p8_code_analysis/receive_functions.rs
@@ -96,7 +96,7 @@ fn check_receive_function(
         );
     }
 
-    let Typing::Resolved(type_id) = binder.node_typing(node.id()) else {
+    let &Typing::Resolved(type_id) = binder.node_typing(node.id()) else {
         unreachable!("receive function definition is not typed");
     };
     let Type::Function(function_type) = types.get_type_by_id(type_id) else {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/meta_types.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/meta_types.rs
@@ -359,7 +359,7 @@ fn test_function_declaration_via_type_name_has_no_mobile_type() {
             .filter_map(|stmt| match stmt {
                 ir::Statement::ExpressionStatement(s) => {
                     let node_id = s.expression.node_id().expect("expression has a node id");
-                    Some(binder.node_typing(node_id))
+                    Some(binder.node_typing(node_id).clone())
                 }
                 _ => None,
             })

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/overloads.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/overloads.rs
@@ -145,7 +145,7 @@ fn test_overloaded_call_operand_narrows_to_selected_overload() {
     let sole_parameter_type = |call: &ir::FunctionCallExpression| -> TypeId {
         let node_id = call.operand.node_id().expect("operand has a node id");
         let type_id = match binder.node_typing(node_id) {
-            Typing::Resolved(type_id) => type_id,
+            &Typing::Resolved(type_id) => type_id,
             other => panic!("operand should be narrowed to a single overload, got {other:?}"),
         };
         let Type::Function(FunctionType {
@@ -208,7 +208,7 @@ fn test_overloaded_declaration_via_type_name_operand_narrows() {
     let selected_definition = |call: &ir::FunctionCallExpression| {
         let node_id = call.operand.node_id().expect("operand has a node id");
         match binder.node_typing(node_id) {
-            Typing::Resolved(type_id) => match types.get_type_by_id(type_id) {
+            &Typing::Resolved(type_id) => match types.get_type_by_id(type_id) {
                 Type::UserMetaType(UserMetaType { definition_id }) => *definition_id,
                 other => panic!("operand should be a declaration meta type, got {other:?}"),
             },


### PR DESCRIPTION
Builds on top of #2079 

`Binder::node_typing` and `common_operand_typing` returned an owned `Typing`. That type is 32 bytes, is not `Copy`, and owns a `Vec` in its `Undetermined` variant, so every lookup paid a move plus drop glue in the caller, and an allocation whenever the typing held an overload set. Both accessors now return `&Typing`, and the p5 accessor ladder (`raw_typing_of_expression`, `check_typing_of_expression`, `check_type_of_value_expression`) hands back borrows as well. Most call sites only inspect the typing or take `as_type_id()` from it and needed no change; the six that genuinely need ownership, because they store the typing, move a `Vec<TypeId>` or a built-in out of it, or call `built_ins_resolver()` while holding it, now clone explicitly at the lookup.

Measured with callgrind over the 9 benchmark projects, against the branch point: `semantic` is 0.75% to 3.58% cheaper (uniswap -1.04M Ir, -2.40%), `ast_analysis` 0.52% to 11.52% cheaper, and `compute_contracts_abi` 2.7% to 4.4% cheaper, while `parser`, `ast_visitor` and `ir_builder` are bit-identical, confirming the change is confined to the semantic path. The largest win is in `ast_analysis`, whose node extensions call `node_typing(id).as_type_id()` throughout and were cloning a whole `Typing` to read a single `TypeId`.

Relative to current `main`, the branch is now 0.75% to 2.21% faster on `semantic` despite adding the new value checks, which had cost 0.59% to 2.94%.
