### PR TITLE
fix(semantic): `creationCode`/`runtimeCode` are not valid for abstract contracts

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/built_ins/mod.rs
@@ -1,7 +1,9 @@
+use slang_solidity_v2_common::nodes::NodeId;
+
 use super::binder::{Binder, Definition, Typing};
 use super::types::{
-    AddressType, ArrayType, BytesType, DataLocation, LiteralKind, MetaType, TupleType, Type,
-    TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
+    AddressType, ArrayType, BytesType, ContractType, DataLocation, LiteralKind, MetaType,
+    TupleType, Type, TypeId, TypeRegistry, UserDefinedValueType, UserMetaType,
 };
 
 mod availability;
@@ -138,6 +140,13 @@ impl<'a> BuiltInsResolver<'a> {
         }
     }
 
+    fn is_abstract_contract(&self, definition_id: NodeId) -> bool {
+        matches!(
+            self.binder.find_definition_by_id(definition_id),
+            Some(Definition::Contract(contract)) if contract.ir_node.is_abstract
+        )
+    }
+
     pub(crate) fn lookup_member_of(
         &self,
         built_in: &InternalBuiltIn,
@@ -171,7 +180,17 @@ impl<'a> BuiltInsResolver<'a> {
                 _ => None,
             },
             InternalBuiltIn::Type(type_id) => match self.types.get_type_by_id(*type_id) {
-                Type::Contract(_) | Type::Library(_) => match symbol {
+                Type::Contract(ContractType { definition_id }) => {
+                    let is_abstract = self.is_abstract_contract(*definition_id);
+                    match symbol {
+                        "name" => Some(InternalBuiltIn::TypeName),
+                        // An abstract contract has no bytecode of its own.
+                        "creationCode" if !is_abstract => Some(InternalBuiltIn::TypeCreationCode),
+                        "runtimeCode" if !is_abstract => Some(InternalBuiltIn::TypeRuntimeCode),
+                        _ => None,
+                    }
+                }
+                Type::Library(_) => match symbol {
                     "name" => Some(InternalBuiltIn::TypeName),
                     "creationCode" => Some(InternalBuiltIn::TypeCreationCode),
                     "runtimeCode" => Some(InternalBuiltIn::TypeRuntimeCode),

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1296,6 +1296,14 @@ mod resolution {
         }
 
         #[test]
+        fn creation_code_on_abstract_contract() -> Result<()> {
+            run(
+                "resolution/member_not_found",
+                "creation_code_on_abstract_contract",
+            )
+        }
+
+        #[test]
         fn external_function_via_super() -> Result<()> {
             run("resolution/member_not_found", "external_function_via_super")
         }
@@ -1376,6 +1384,14 @@ mod resolution {
         #[test]
         fn pop_on_value_type() -> Result<()> {
             run("resolution/member_not_found", "pop_on_value_type")
+        }
+
+        #[test]
+        fn runtime_code_on_abstract_contract() -> Result<()> {
+            run(
+                "resolution/member_not_found",
+                "runtime_code_on_abstract_contract",
+            )
         }
 
         #[test]

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/creation_code_on_abstract_contract/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/creation_code_on_abstract_contract/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/member-not-found] Error: Member 'creationCode' not found or not visible after argument-dependent lookup.
+    ╭─[input.sol:13:28]
+    │
+ 13 │         return type(Other).creationCode;
+    │                            ──────┬─────  
+    │                                  ╰─────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/creation_code_on_abstract_contract/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/creation_code_on_abstract_contract/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "creationCode" not found or not visible after argument-dependent lookup in type(contract Other).
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return type(Other).creationCode;
+    │                ────────────┬───────────  
+    │                            ╰───────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/creation_code_on_abstract_contract/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/creation_code_on_abstract_contract/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+abstract contract Other {
+    function f() public virtual;
+}
+
+contract Concrete {}
+
+contract C {
+    function missing() internal pure returns (bytes memory) {
+        // An abstract contract has no bytecode of its own.
+        return type(Other).creationCode;
+    }
+
+    function present() internal pure returns (bytes memory) {
+        return type(Concrete).creationCode;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/runtime_code_on_abstract_contract/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/runtime_code_on_abstract_contract/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/member-not-found] Error: Member 'runtimeCode' not found or not visible after argument-dependent lookup.
+    ╭─[input.sol:13:28]
+    │
+ 13 │         return type(Other).runtimeCode;
+    │                            ─────┬─────  
+    │                                 ╰─────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/runtime_code_on_abstract_contract/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/runtime_code_on_abstract_contract/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "runtimeCode" not found or not visible after argument-dependent lookup in type(contract Other).
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return type(Other).runtimeCode;
+    │                ───────────┬───────────  
+    │                           ╰───────────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/runtime_code_on_abstract_contract/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/runtime_code_on_abstract_contract/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+abstract contract Other {
+    function f() public virtual;
+}
+
+contract Concrete {}
+
+contract C {
+    function missing() internal pure returns (bytes memory) {
+        // An abstract contract has no bytecode of its own.
+        return type(Other).runtimeCode;
+    }
+
+    function present() internal pure returns (bytes memory) {
+        return type(Concrete).runtimeCode;
+    }
+}


### PR DESCRIPTION
Builds on top of #2067
