### PR TITLE
fix(semantic): Restrict `super` scoped lookups to internally visible functions

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/binder/mod.rs
@@ -631,7 +631,13 @@ impl Binder {
                         ResolveOptions::This(_) | ResolveOptions::External => {
                             definition.is_externally_visible()
                         }
-                        ResolveOptions::Super(_) => definition.is_internally_visible(),
+                        // `super` reaches the functions of the bases, and
+                        // nothing else: not state variables, constants, or
+                        // type definitions.
+                        ResolveOptions::Super(_) => {
+                            matches!(definition, Definition::Function(_))
+                                && definition.is_internally_visible()
+                        }
                     };
                     if visible {
                         results.push(*definition_id);

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -1296,11 +1296,21 @@ mod resolution {
         }
 
         #[test]
+        fn constant_via_super() -> Result<()> {
+            run("resolution/member_not_found", "constant_via_super")
+        }
+
+        #[test]
         fn creation_code_on_abstract_contract() -> Result<()> {
             run(
                 "resolution/member_not_found",
                 "creation_code_on_abstract_contract",
             )
+        }
+
+        #[test]
+        fn event_via_super() -> Result<()> {
+            run("resolution/member_not_found", "event_via_super")
         }
 
         #[test]
@@ -1392,6 +1402,14 @@ mod resolution {
         }
 
         #[test]
+        fn public_state_variable_via_super() -> Result<()> {
+            run(
+                "resolution/member_not_found",
+                "public_state_variable_via_super",
+            )
+        }
+
+        #[test]
         fn push_on_memory_array() -> Result<()> {
             run("resolution/member_not_found", "push_on_memory_array")
         }
@@ -1410,6 +1428,11 @@ mod resolution {
                 "resolution/member_not_found",
                 "selector_on_internal_function",
             )
+        }
+
+        #[test]
+        fn state_variable_via_super() -> Result<()> {
+            run("resolution/member_not_found", "state_variable_via_super")
         }
     }
 

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/constant_via_super/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/constant_via_super/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/member-not-found] Error: Member 'X' not found or not visible after argument-dependent lookup.
+    ╭─[input.sol:13:22]
+    │
+ 13 │         return super.X;
+    │                      ┬  
+    │                      ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/constant_via_super/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/constant_via_super/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "X" not found or not visible after argument-dependent lookup in type(contract super B).
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return super.X;
+    │                ───┬───  
+    │                   ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/constant_via_super/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/constant_via_super/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A {
+    uint256 internal constant X = 1;
+
+    function f() internal pure virtual {}
+}
+
+contract B is A {
+    function missing() internal pure returns (uint256) {
+        // `super` reaches functions, not constants.
+        return super.X;
+    }
+
+    function present() internal pure {
+        super.f();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/event_via_super/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/event_via_super/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/member-not-found] Error: Member 'E' not found or not visible after argument-dependent lookup.
+    ╭─[input.sol:13:22]
+    │
+ 13 │         return super.E.selector;
+    │                      ┬  
+    │                      ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/event_via_super/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/event_via_super/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "E" not found or not visible after argument-dependent lookup in type(contract super B).
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return super.E.selector;
+    │                ───┬───  
+    │                   ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/event_via_super/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/event_via_super/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A {
+    event E(uint256 value);
+
+    function f() internal pure virtual {}
+}
+
+contract B is A {
+    function missing() internal pure returns (bytes32) {
+        // `super` reaches functions, not events.
+        return super.E.selector;
+    }
+
+    function present() internal pure {
+        super.f();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/public_state_variable_via_super/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/public_state_variable_via_super/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/member-not-found] Error: Member 'x' not found or not visible after argument-dependent lookup.
+    ╭─[input.sol:13:22]
+    │
+ 13 │         return super.x();
+    │                      ┬  
+    │                      ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/public_state_variable_via_super/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/public_state_variable_via_super/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "x" not found or not visible after argument-dependent lookup in type(contract super B).
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return super.x();
+    │                ───┬───  
+    │                   ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/public_state_variable_via_super/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/public_state_variable_via_super/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A {
+    uint256 public x;
+
+    function f() internal pure virtual {}
+}
+
+contract B is A {
+    function missing() internal view returns (uint256) {
+        // A public state variable getter is not reachable through `super`.
+        return super.x();
+    }
+
+    function present() internal pure {
+        super.f();
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/state_variable_via_super/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/state_variable_via_super/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/member-not-found] Error: Member 'x' not found or not visible after argument-dependent lookup.
+    ╭─[input.sol:13:22]
+    │
+ 13 │         return super.x;
+    │                      ┬  
+    │                      ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/state_variable_via_super/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/state_variable_via_super/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "x" not found or not visible after argument-dependent lookup in type(contract super B).
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return super.x;
+    │                ───┬───  
+    │                   ╰───── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/state_variable_via_super/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/resolution/member_not_found/state_variable_via_super/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract A {
+    uint256 internal x;
+
+    function f() internal pure virtual {}
+}
+
+contract B is A {
+    function missing() internal view returns (uint256) {
+        // `super` reaches functions, not state variables.
+        return super.x;
+    }
+
+    function present() internal pure {
+        super.f();
+    }
+}


### PR DESCRIPTION
Builds on top of #2067
