### PR TITLE
[v2] fix(parser): Report state variable attributes that are not valid

### DIFF
--- a/crates/solidity-v2/inputs/language/src/definition.rs
+++ b/crates/solidity-v2/inputs/language/src/definition.rs
@@ -1876,7 +1876,7 @@ StateVariableDefinition: StateVariableDefinition = {
     // If the function type has no return, then we don't directly parse state variable attributes, we only do it if
     // we see a special one (one that can be a state variable attribute but not a function type attribute).
     <mut function_type: FunctionTypeInternalNoReturn> <special_attributes: (<SpecialStateVariableAttribute> <StateVariableAttributes>)?> <name: Identifier>  <value: (StateVariableDefinitionValue)?>  <semicolon: Semicolon>  => {
-        let mut extra_attributes = parser_helpers::extract_extra_attributes(&mut function_type);
+        let mut extra_attributes = parser_helpers::extract_extra_attributes(&mut function_type, ctx);
         if let Some(special_attributes) = special_attributes {
             extra_attributes.push(special_attributes.0);
             extra_attributes.extend(special_attributes.1.elements);

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/grammar.generated.lalrpop
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/grammar.generated.lalrpop
@@ -443,8 +443,8 @@ BracedContractMembers: (OpenBrace, ContractMembers, CloseBrace) =
     Semicolon> =>
     {
         let mut extra_attributes =
-        parser_helpers::extract_extra_attributes(&mut function_type); if let
-        Some(special_attributes) = special_attributes
+        parser_helpers::extract_extra_attributes(&mut function_type, ctx); if
+        let Some(special_attributes) = special_attributes
         {
             extra_attributes.push(special_attributes.0);
             extra_attributes.extend(special_attributes.1.elements);

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/mod.rs
@@ -47,6 +47,8 @@ pub(crate) struct GrammarCtx<'a> {
     pub file_id: &'a FileId,
     /// Diagnostics accumulated during parsing.
     pub diagnostics: DiagnosticCollection,
+    /// Version being parsed, for diagnostics that depend on which syntax it allows.
+    pub language_version: LanguageVersion,
 }
 
 /// The output of a parse operation, containing both the source unit and any diagnostics.
@@ -72,6 +74,7 @@ impl Parser {
             source,
             file_id,
             diagnostics: DiagnosticCollection::default(),
+            language_version,
         };
         let result = parser.parse(&mut ctx, lexer);
         match result {

--- a/crates/solidity-v2/outputs/cargo/parser/src/parser/parser_helpers.rs
+++ b/crates/solidity-v2/outputs/cargo/parser/src/parser/parser_helpers.rs
@@ -4,7 +4,11 @@
 
 use std::iter::once;
 
-use slang_solidity_v2_common::diagnostics::kinds::syntax::ExpectedArrayLengthExpression;
+use slang_solidity_v2_common::diagnostics::kinds::syntax::{
+    ExpectedArrayLengthExpression, InvalidMutability, InvalidVisibility,
+};
+use slang_solidity_v2_common::terminals::TerminalKind;
+use slang_solidity_v2_common::versions::LanguageVersion;
 use slang_solidity_v2_cst::structured_cst::nodes::{
     CloseBracket, ElementaryType, Expression, FunctionTypeAttribute, FunctionTypeStruct,
     Identifier, IdentifierPath, IdentifierPathElement, IndexAccessEnd, OpenBracket, Period,
@@ -15,6 +19,7 @@ use slang_solidity_v2_cst::structured_cst::nodes::{
     new_member_access_expression, new_type_name_array_type_name, new_type_name_elementary_type,
     new_type_name_identifier_path,
 };
+use slang_solidity_v2_cst::structured_cst::text_range::TextRange;
 
 use crate::parser::GrammarCtx;
 
@@ -213,9 +218,15 @@ pub(crate) fn new_expression_separated_identifier_path(
 
 /// We use this function to share attributes between a state variable that has a function type.
 /// We find and split the attributes from the function type as needed
-/// TODO(v2) fail gracefully if a wrong attribute is found
+///
+/// Extracted attributes belong to the state variable, so the ones that are not
+/// valid there (a mutability, or an `external` visibility) are reported as
+/// diagnostics and dropped.
+///
+/// TODO(error-recovery): Once the CST allows for error nodes, the dropped attributes should be present in there.
 pub(crate) fn extract_extra_attributes(
     fun_type: &mut FunctionTypeStruct,
+    ctx: &mut GrammarCtx<'_>,
 ) -> Vec<StateVariableAttribute> {
     // Move all matching attributes to extra_attributes if duplicate_found, else only the first occurrence
     let mut seen_visibility = false;
@@ -258,9 +269,43 @@ pub(crate) fn extract_extra_attributes(
                 FunctionTypeAttribute::PublicKeyword(terminal) => {
                     Some(StateVariableAttribute::PublicKeyword(terminal))
                 }
-                _ => {
-                    // TODO(v2): For now we skip this item
-                    // but we should fail gracefully in the future
+                // A state variable cannot be `external`
+                FunctionTypeAttribute::ExternalKeyword(terminal) => {
+                    ctx.diagnostics.push(
+                        ctx.file_id.to_owned(),
+                        terminal.range,
+                        InvalidVisibility {
+                            valid: vec![
+                                TerminalKind::PublicKeyword,
+                                TerminalKind::InternalKeyword,
+                                TerminalKind::PrivateKeyword,
+                            ],
+                        },
+                    );
+                    None
+                }
+                // Neither can it declare a function mutability
+                attr @ (FunctionTypeAttribute::PureKeyword(_)
+                | FunctionTypeAttribute::ViewKeyword(_)
+                | FunctionTypeAttribute::PayableKeyword(_)) => {
+                    let range = attr
+                        .calculate_text_range()
+                        .expect("Function type attributes always have a range");
+                    // `transient` only exists from 0.8.27 onwards, so offering it
+                    // below that would name a keyword the version check rejects.
+                    let mut valid = vec![
+                        TerminalKind::ConstantKeyword,
+                        TerminalKind::ImmutableKeyword,
+                    ];
+                    if ctx.language_version >= LanguageVersion::V0_8_27 {
+                        valid.push(TerminalKind::TransientKeyword);
+                    }
+
+                    ctx.diagnostics.push(
+                        ctx.file_id.to_owned(),
+                        range,
+                        InvalidMutability { valid },
+                    );
                     None
                 }
             }

--- a/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/cst_output/snapshots.generated.rs
@@ -1847,6 +1847,11 @@ mod state_variable_definition {
     use super::*;
 
     #[test]
+    fn function_type_extra_attributes() -> Result<()> {
+        run("StateVariableDefinition", "function_type_extra_attributes")
+    }
+
+    #[test]
     fn transient() -> Result<()> {
         run("StateVariableDefinition", "transient")
     }

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -3193,6 +3193,19 @@ mod syntax {
         fn receive_function() -> Result<()> {
             run("syntax/invalid_mutability", "receive_function")
         }
+
+        #[test]
+        fn state_variable_function_type() -> Result<()> {
+            run("syntax/invalid_mutability", "state_variable_function_type")
+        }
+
+        #[test]
+        fn state_variable_function_type_multiple() -> Result<()> {
+            run(
+                "syntax/invalid_mutability",
+                "state_variable_function_type_multiple",
+            )
+        }
     }
 
     mod invalid_version_specifier {
@@ -3311,6 +3324,11 @@ mod syntax {
         #[test]
         fn receive_function() -> Result<()> {
             run("syntax/invalid_visibility", "receive_function")
+        }
+
+        #[test]
+        fn state_variable_function_type() -> Result<()> {
+            run("syntax/invalid_visibility", "state_variable_function_type")
         }
     }
 

--- a/crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/generated/0.8.0-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/generated/0.8.0-failure.yml
@@ -1,0 +1,147 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     // The attributes of a function type without a return are greedily parsed,   │ 13..91
+  3  │     // so the ones that follow a repeated visibility belong to the state         │ 92..164
+  4  │     // variable. Those that are not valid there are reported as errors.          │ 165..236
+  5  │     function() internal public x;                                                │ 237..270
+  6  │     function() internal public payable y;                                        │ 271..312
+  7  │     function() internal public external z;                                       │ 313..355
+  8  │     function() internal public view constant w = f;                              │ 356..407
+  9  │     function() internal external v;                                              │ 408..443
+  10 │     function() internal public pure u;                                           │ 444..482
+  11 │ }                                                                                │ 483..484
+
+Errors: # 5 total
+  - >
+    [syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:6:32]
+       │
+     6 │     function() internal public payable y;
+       │                                ───┬───  
+       │                                   ╰───── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-visibility] Error: Invalid visibility for this definition. Expected 'PublicKeyword' or 'InternalKeyword' or 'PrivateKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:7:32]
+       │
+     7 │     function() internal public external z;
+       │                                ────┬───  
+       │                                    ╰───── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:8:32]
+       │
+     8 │     function() internal public view constant w = f;
+       │                                ──┬─  
+       │                                  ╰─── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-visibility] Error: Invalid visibility for this definition. Expected 'PublicKeyword' or 'InternalKeyword' or 'PrivateKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:9:25]
+       │
+     9 │     function() internal external v;
+       │                         ────┬───  
+       │                             ╰───── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword'.
+        ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:10:32]
+        │
+     10 │     function() internal public pure u;
+        │                                ──┬─  
+        │                                  ╰─── Error occurred here.
+    ────╯
+Tree:
+  - (root꞉ SourceUnit): # "contract C {\n    // The attributes of a function t..." (0..484)
+      - (members꞉ SourceUnitMembers): # "contract C {\n    // The attributes of a function t..." (0..484)
+          - (item꞉ SourceUnitMember) ► (contract_definition꞉ ContractDefinition): # "contract C {\n    // The attributes of a function t..." (0..484)
+              - (contract_keyword꞉ ContractKeyword): "contract" # (0..8)
+              - (name꞉ Identifier): "C" # (9..10)
+              - (specifiers꞉ ContractSpecifiers): []
+              - (open_brace꞉ OpenBrace): "{" # (11..12)
+              - (members꞉ ContractMembers): # "function() internal public x;\n    function() inter..." (241..482)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public x;" (241..270)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (241..260)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (241..249)
+                          - (parameters꞉ ParametersDeclaration): # "()" (249..251)
+                              - (open_paren꞉ OpenParen): "(" # (249..250)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (250..251)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (252..260)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (252..260)
+                      - (attributes꞉ StateVariableAttributes): # "public" (261..267)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (261..267)
+                      - (name꞉ Identifier): "x" # (268..269)
+                      - (semicolon꞉ Semicolon): ";" # (269..270)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public payable y;" (275..312)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (275..294)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (275..283)
+                          - (parameters꞉ ParametersDeclaration): # "()" (283..285)
+                              - (open_paren꞉ OpenParen): "(" # (283..284)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (284..285)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (286..294)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (286..294)
+                      - (attributes꞉ StateVariableAttributes): # "public" (295..301)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (295..301)
+                      - (name꞉ Identifier): "y" # (310..311)
+                      - (semicolon꞉ Semicolon): ";" # (311..312)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public external z;" (317..355)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (317..336)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (317..325)
+                          - (parameters꞉ ParametersDeclaration): # "()" (325..327)
+                              - (open_paren꞉ OpenParen): "(" # (325..326)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (326..327)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (328..336)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (328..336)
+                      - (attributes꞉ StateVariableAttributes): # "public" (337..343)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (337..343)
+                      - (name꞉ Identifier): "z" # (353..354)
+                      - (semicolon꞉ Semicolon): ";" # (354..355)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public view constant w = f;" (360..407)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (360..379)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (360..368)
+                          - (parameters꞉ ParametersDeclaration): # "()" (368..370)
+                              - (open_paren꞉ OpenParen): "(" # (368..369)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (369..370)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (371..379)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (371..379)
+                      - (attributes꞉ StateVariableAttributes): # "public view constant" (380..400)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (380..386)
+                          - (item꞉ StateVariableAttribute) ► (constant_keyword꞉ ConstantKeyword): "constant" # (392..400)
+                      - (name꞉ Identifier): "w" # (401..402)
+                      - (value꞉ StateVariableDefinitionValue): # "= f" (403..406)
+                          - (equal꞉ Equal): "=" # (403..404)
+                          - (value꞉ Expression) ► (identifier꞉ Identifier): "f" # (405..406)
+                      - (semicolon꞉ Semicolon): ";" # (406..407)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal external v;" (412..443)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (412..431)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (412..420)
+                          - (parameters꞉ ParametersDeclaration): # "()" (420..422)
+                              - (open_paren꞉ OpenParen): "(" # (420..421)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (421..422)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (423..431)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (423..431)
+                      - (attributes꞉ StateVariableAttributes): []
+                      - (name꞉ Identifier): "v" # (441..442)
+                      - (semicolon꞉ Semicolon): ";" # (442..443)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public pure u;" (448..482)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (448..467)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (448..456)
+                          - (parameters꞉ ParametersDeclaration): # "()" (456..458)
+                              - (open_paren꞉ OpenParen): "(" # (456..457)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (457..458)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (459..467)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (459..467)
+                      - (attributes꞉ StateVariableAttributes): # "public" (468..474)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (468..474)
+                      - (name꞉ Identifier): "u" # (480..481)
+                      - (semicolon꞉ Semicolon): ";" # (481..482)
+              - (close_brace꞉ CloseBrace): "}" # (483..484)

--- a/crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/generated/0.8.27-failure.yml
+++ b/crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/generated/0.8.27-failure.yml
@@ -1,0 +1,147 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Source: >
+  1  │ contract C {                                                                     │ 0..12
+  2  │     // The attributes of a function type without a return are greedily parsed,   │ 13..91
+  3  │     // so the ones that follow a repeated visibility belong to the state         │ 92..164
+  4  │     // variable. Those that are not valid there are reported as errors.          │ 165..236
+  5  │     function() internal public x;                                                │ 237..270
+  6  │     function() internal public payable y;                                        │ 271..312
+  7  │     function() internal public external z;                                       │ 313..355
+  8  │     function() internal public view constant w = f;                              │ 356..407
+  9  │     function() internal external v;                                              │ 408..443
+  10 │     function() internal public pure u;                                           │ 444..482
+  11 │ }                                                                                │ 483..484
+
+Errors: # 5 total
+  - >
+    [syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword' or 'TransientKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:6:32]
+       │
+     6 │     function() internal public payable y;
+       │                                ───┬───  
+       │                                   ╰───── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-visibility] Error: Invalid visibility for this definition. Expected 'PublicKeyword' or 'InternalKeyword' or 'PrivateKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:7:32]
+       │
+     7 │     function() internal public external z;
+       │                                ────┬───  
+       │                                    ╰───── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword' or 'TransientKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:8:32]
+       │
+     8 │     function() internal public view constant w = f;
+       │                                ──┬─  
+       │                                  ╰─── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-visibility] Error: Invalid visibility for this definition. Expected 'PublicKeyword' or 'InternalKeyword' or 'PrivateKeyword'.
+       ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:9:25]
+       │
+     9 │     function() internal external v;
+       │                         ────┬───  
+       │                             ╰───── Error occurred here.
+    ───╯
+  - >
+    [syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword' or 'TransientKeyword'.
+        ╭─[crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol:10:32]
+        │
+     10 │     function() internal public pure u;
+        │                                ──┬─  
+        │                                  ╰─── Error occurred here.
+    ────╯
+Tree:
+  - (root꞉ SourceUnit): # "contract C {\n    // The attributes of a function t..." (0..484)
+      - (members꞉ SourceUnitMembers): # "contract C {\n    // The attributes of a function t..." (0..484)
+          - (item꞉ SourceUnitMember) ► (contract_definition꞉ ContractDefinition): # "contract C {\n    // The attributes of a function t..." (0..484)
+              - (contract_keyword꞉ ContractKeyword): "contract" # (0..8)
+              - (name꞉ Identifier): "C" # (9..10)
+              - (specifiers꞉ ContractSpecifiers): []
+              - (open_brace꞉ OpenBrace): "{" # (11..12)
+              - (members꞉ ContractMembers): # "function() internal public x;\n    function() inter..." (241..482)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public x;" (241..270)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (241..260)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (241..249)
+                          - (parameters꞉ ParametersDeclaration): # "()" (249..251)
+                              - (open_paren꞉ OpenParen): "(" # (249..250)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (250..251)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (252..260)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (252..260)
+                      - (attributes꞉ StateVariableAttributes): # "public" (261..267)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (261..267)
+                      - (name꞉ Identifier): "x" # (268..269)
+                      - (semicolon꞉ Semicolon): ";" # (269..270)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public payable y;" (275..312)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (275..294)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (275..283)
+                          - (parameters꞉ ParametersDeclaration): # "()" (283..285)
+                              - (open_paren꞉ OpenParen): "(" # (283..284)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (284..285)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (286..294)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (286..294)
+                      - (attributes꞉ StateVariableAttributes): # "public" (295..301)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (295..301)
+                      - (name꞉ Identifier): "y" # (310..311)
+                      - (semicolon꞉ Semicolon): ";" # (311..312)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public external z;" (317..355)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (317..336)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (317..325)
+                          - (parameters꞉ ParametersDeclaration): # "()" (325..327)
+                              - (open_paren꞉ OpenParen): "(" # (325..326)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (326..327)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (328..336)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (328..336)
+                      - (attributes꞉ StateVariableAttributes): # "public" (337..343)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (337..343)
+                      - (name꞉ Identifier): "z" # (353..354)
+                      - (semicolon꞉ Semicolon): ";" # (354..355)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public view constant w = f;" (360..407)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (360..379)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (360..368)
+                          - (parameters꞉ ParametersDeclaration): # "()" (368..370)
+                              - (open_paren꞉ OpenParen): "(" # (368..369)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (369..370)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (371..379)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (371..379)
+                      - (attributes꞉ StateVariableAttributes): # "public view constant" (380..400)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (380..386)
+                          - (item꞉ StateVariableAttribute) ► (constant_keyword꞉ ConstantKeyword): "constant" # (392..400)
+                      - (name꞉ Identifier): "w" # (401..402)
+                      - (value꞉ StateVariableDefinitionValue): # "= f" (403..406)
+                          - (equal꞉ Equal): "=" # (403..404)
+                          - (value꞉ Expression) ► (identifier꞉ Identifier): "f" # (405..406)
+                      - (semicolon꞉ Semicolon): ";" # (406..407)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal external v;" (412..443)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (412..431)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (412..420)
+                          - (parameters꞉ ParametersDeclaration): # "()" (420..422)
+                              - (open_paren꞉ OpenParen): "(" # (420..421)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (421..422)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (423..431)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (423..431)
+                      - (attributes꞉ StateVariableAttributes): []
+                      - (name꞉ Identifier): "v" # (441..442)
+                      - (semicolon꞉ Semicolon): ";" # (442..443)
+                  - (item꞉ ContractMember) ► (state_variable_definition꞉ StateVariableDefinition): # "function() internal public pure u;" (448..482)
+                      - (type_name꞉ TypeName) ► (function_type꞉ FunctionType): # "function() internal" (448..467)
+                          - (function_keyword꞉ FunctionKeyword): "function" # (448..456)
+                          - (parameters꞉ ParametersDeclaration): # "()" (456..458)
+                              - (open_paren꞉ OpenParen): "(" # (456..457)
+                              - (parameters꞉ Parameters): []
+                              - (close_paren꞉ CloseParen): ")" # (457..458)
+                          - (attributes꞉ FunctionTypeAttributes): # "internal" (459..467)
+                              - (item꞉ FunctionTypeAttribute) ► (internal_keyword꞉ InternalKeyword): "internal" # (459..467)
+                      - (attributes꞉ StateVariableAttributes): # "public" (468..474)
+                          - (item꞉ StateVariableAttribute) ► (public_keyword꞉ PublicKeyword): "public" # (468..474)
+                      - (name꞉ Identifier): "u" # (480..481)
+                      - (semicolon꞉ Semicolon): ";" # (481..482)
+              - (close_brace꞉ CloseBrace): "}" # (483..484)

--- a/crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol
+++ b/crates/solidity-v2/testing/snapshots/cst_output/StateVariableDefinition/function_type_extra_attributes/input.sol
@@ -1,0 +1,11 @@
+contract C {
+    // The attributes of a function type without a return are greedily parsed,
+    // so the ones that follow a repeated visibility belong to the state
+    // variable. Those that are not valid there are reported as errors.
+    function() internal public x;
+    function() internal public payable y;
+    function() internal public external z;
+    function() internal public view constant w = f;
+    function() internal external v;
+    function() internal public pure u;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword'.
+   ╭─[input.sol:8:32]
+   │
+ 8 │     function() internal public payable x;
+   │                                ───┬───  
+   │                                   ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/generated/slang/0.8.27-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/generated/slang/0.8.27-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword' or 'TransientKeyword'.
+   ╭─[input.sol:8:32]
+   │
+ 8 │     function() internal public payable x;
+   │                                ───┬───  
+   │                                   ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got 'payable'
+   ╭─[input.sol:8:32]
+   │
+ 8 │     function() internal public payable x;
+   │                                ───┬───  
+   │                                   ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The function type greedily takes the attributes, so everything after the
+    // repeated visibility belongs to the state variable. A mutability is not
+    // valid there.
+    function() internal public payable x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword'.
+   ╭─[input.sol:7:32]
+   │
+ 7 │     function() internal public payable pure external x;
+   │                                ───┬───  
+   │                                   ╰───── Error occurred here.
+───╯
+
+[syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword'.
+   ╭─[input.sol:7:40]
+   │
+ 7 │     function() internal public payable pure external x;
+   │                                        ──┬─  
+   │                                          ╰─── Error occurred here.
+───╯
+
+[syntax/invalid-visibility] Error: Invalid visibility for this definition. Expected 'PublicKeyword' or 'InternalKeyword' or 'PrivateKeyword'.
+   ╭─[input.sol:7:45]
+   │
+ 7 │     function() internal public payable pure external x;
+   │                                             ────┬───  
+   │                                                 ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/generated/slang/0.8.27-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/generated/slang/0.8.27-failure.txt
@@ -1,0 +1,27 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 3
+
+[syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword' or 'TransientKeyword'.
+   ╭─[input.sol:7:32]
+   │
+ 7 │     function() internal public payable pure external x;
+   │                                ───┬───  
+   │                                   ╰───── Error occurred here.
+───╯
+
+[syntax/invalid-mutability] Error: Invalid mutability for this definition. Expected 'ConstantKeyword' or 'ImmutableKeyword' or 'TransientKeyword'.
+   ╭─[input.sol:7:40]
+   │
+ 7 │     function() internal public payable pure external x;
+   │                                        ──┬─  
+   │                                          ╰─── Error occurred here.
+───╯
+
+[syntax/invalid-visibility] Error: Invalid visibility for this definition. Expected 'PublicKeyword' or 'InternalKeyword' or 'PrivateKeyword'.
+   ╭─[input.sol:7:45]
+   │
+ 7 │     function() internal public payable pure external x;
+   │                                             ────┬───  
+   │                                                 ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got 'payable'
+   ╭─[input.sol:7:32]
+   │
+ 7 │     function() internal public payable pure external x;
+   │                                ───┬───  
+   │                                   ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_mutability/state_variable_function_type_multiple/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // Every invalid attribute extracted from the function type gets its own
+    // diagnostic: two mutabilities and an `external` visibility.
+    function() internal public payable pure external x;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_visibility/state_variable_function_type/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_visibility/state_variable_function_type/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[syntax/invalid-visibility] Error: Invalid visibility for this definition. Expected 'PublicKeyword' or 'InternalKeyword' or 'PrivateKeyword'.
+   ╭─[input.sol:8:32]
+   │
+ 8 │     function() internal public external x;
+   │                                ────┬───  
+   │                                    ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_visibility/state_variable_function_type/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_visibility/state_variable_function_type/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[ParserError 2314] Error: Expected identifier but got 'external'
+   ╭─[input.sol:8:32]
+   │
+ 8 │     function() internal public external x;
+   │                                ────┬───  
+   │                                    ╰───── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_visibility/state_variable_function_type/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/syntax/invalid_visibility/state_variable_function_type/input.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+contract C {
+    // The function type greedily takes the attributes, so everything after the
+    // repeated visibility belongs to the state variable. 'external' is not a
+    // valid visibility there.
+    function() internal public external x;
+}


### PR DESCRIPTION
Removes an old `TODO` on the parser.

Given how we have to parse state variables of function types, some attributes are checked by a pass rather than by the parser itself.

Before they were silently dropped, this PR emits diagnostics for those cases.

The alternative is to emit a parser error diagnostic, but I think this is strictly better.