### PR TITLE
feat(diagnostics): Further restrict meta types in most value checks

### DIFF
--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/typing.rs
@@ -74,13 +74,32 @@ impl Pass<'_> {
         typing
     }
 
-    /// The type of `node` in a position that requires a value. Reports the
-    /// overload set [`Self::check_typing_of_expression`] does, and on top of it
-    /// the typings that name something which is not a value: a built-in (a
+    /// The type of `node` in a position that requires a value. On top of
+    /// [`Self::check_type_of_value_or_type_name_expression`], an expression
+    /// that denotes a type or a module is not a value either.
+    #[inline]
+    pub(super) fn check_type_of_value_expression(
+        &mut self,
+        node: &ir::Expression,
+    ) -> Option<TypeId> {
+        let type_id = self.check_type_of_value_or_type_name_expression(node)?;
+        if self.types.get_type_by_id(type_id).is_meta_type() {
+            self.report_expression_not_a_value(node, NotAValueKind::TypeOrModule);
+            return None;
+        }
+        Some(type_id)
+    }
+
+    /// The type of `node` in a position that takes either a value or a type
+    /// name, so a meta-type is left alone: the operand of an index access
+    /// (`uint[]`), a component of a tuple and an argument of a built-in call
+    /// (`abi.decode(data, (uint, bool))`). Reports the overload set
+    /// [`Self::check_typing_of_expression`] does, and on top of it the typings
+    /// that name something which is neither a value nor a type: a built-in (a
     /// namespace such as `abi`, or a built-in function), `super`, and an
     /// uncalled `new`.
     #[inline]
-    pub(super) fn check_type_of_value_expression(
+    pub(super) fn check_type_of_value_or_type_name_expression(
         &mut self,
         node: &ir::Expression,
     ) -> Option<TypeId> {
@@ -711,16 +730,36 @@ impl Pass<'_> {
         Typing::Resolved(type_id)
     }
 
+    /// Collects the types of `arguments`, each of which is a value position.
     pub(super) fn collect_positional_argument_types(
         &mut self,
         arguments: &[ir::Expression],
+    ) -> Option<Vec<TypeId>> {
+        self.collect_argument_types(arguments, Self::check_type_of_value_expression)
+    }
+
+    /// Collects the types of `arguments` for a callee that accepts a type name
+    /// in one of them: the second argument of `abi.decode`, the function
+    /// `abi.encodeCall` encodes a call to, and the library name a conversion
+    /// takes in `address(L)`. Which of them is valid is up to the callee.
+    pub(super) fn collect_argument_types_allowing_type_names(
+        &mut self,
+        arguments: &[ir::Expression],
+    ) -> Option<Vec<TypeId>> {
+        self.collect_argument_types(arguments, Self::check_type_of_value_or_type_name_expression)
+    }
+
+    fn collect_argument_types(
+        &mut self,
+        arguments: &[ir::Expression],
+        check: fn(&mut Self, &ir::Expression) -> Option<TypeId>,
     ) -> Option<Vec<TypeId>> {
         // Every argument is checked before the result is folded, so one that has
         // no type does not stop the rest from being checked (and reported).
         let mut types = Vec::with_capacity(arguments.len());
         let mut all_typed = true;
         for argument in arguments {
-            match self.check_type_of_value_expression(argument) {
+            match check(self, argument) {
                 Some(type_id) => types.push(type_id),
                 None => all_typed = false,
             }
@@ -734,7 +773,19 @@ impl Pass<'_> {
         arguments: &[ir::Expression],
     ) -> Typing {
         let operand_typing = self.raw_typing_of_expression(&node.operand).clone();
-        let argument_types = self.collect_positional_argument_types(arguments);
+        // A built-in and a conversion each accept a type name in an argument,
+        // so theirs are not all value positions; see
+        // [`Self::collect_argument_types_allowing_type_names`].
+        let accepts_type_names = match &operand_typing {
+            Typing::BuiltIn(_) => true,
+            Typing::Resolved(type_id) => self.types.get_type_by_id(*type_id).is_meta_type(),
+            _ => false,
+        };
+        let argument_types = if accepts_type_names {
+            self.collect_argument_types_allowing_type_names(arguments)
+        } else {
+            self.collect_positional_argument_types(arguments)
+        };
 
         match operand_typing {
             Typing::Unresolved => {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/p5_resolve_references/visitor.rs
@@ -380,8 +380,14 @@ impl Visitor for Pass<'_> {
         } else {
             let mut types = Vec::new();
             for item in node.items.iter() {
+                // A component may name a type, as every component of the
+                // second argument of `abi.decode` does. The tuple then denotes
+                // a type rather than a value, which the enclosing context
+                // rejects where it requires one.
                 let type_id = match &item.expression {
-                    Some(expression) => self.check_type_of_value_expression(expression),
+                    Some(expression) => {
+                        self.check_type_of_value_or_type_name_expression(expression)
+                    }
                     None => None,
                 };
                 types.push(type_id.unwrap_or(self.types.void()));
@@ -467,7 +473,9 @@ impl Visitor for Pass<'_> {
             self.check_type_of_value_expression(index);
         }
 
-        let typing = match self.check_type_of_value_expression(&node.operand) {
+        // The operand may name a type, in which case indexing it names the
+        // array type of it (eg. the `uint[]` in `abi.decode(data, (uint[]))`).
+        let typing = match self.check_type_of_value_or_type_name_expression(&node.operand) {
             Some(operand_type_id) => {
                 match self.types.get_type_by_id(operand_type_id) {
                     Type::Array(ArrayType {

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/meta_types.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/meta_types.rs
@@ -304,14 +304,6 @@ fn test_tuple_of_type_names_is_a_tuple_of_meta_types() {
 }
 
 #[test]
-fn test_type_name_has_no_mobile_type() {
-    // A type name denotes a type rather than a value, so nothing reconciles
-    // two of them.
-    let (type_, _) = expression("E + E").with_members("enum E { A }").into_type();
-    assert_eq!(type_, None);
-}
-
-#[test]
 fn test_function_declaration_via_type_name_has_no_mobile_type() {
     // A function reached through a contract/interface *type name* (`C.g`) is a
     // non-value declaration with no mobile type — only good for `.selector` —

--- a/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/overloads.rs
+++ b/crates/solidity-v2/outputs/cargo/semantic/src/passes/tests/typing/overloads.rs
@@ -98,22 +98,6 @@ fn test_overload_resolution_rejects_byte_array_narrowing() {
 }
 
 #[test]
-fn test_meta_type_argument_does_not_match_overloads() {
-    // Passing a type name as an argument must not match any overload
-    // candidate during disambiguation.
-    let context = r#"
-        function f(uint x) internal pure returns (bool) { return x > 0; }
-        function f(bool x) internal pure returns (uint) { return x ? 1 : 0; }
-    "#;
-    assert_eq!(
-        Some(NoMatchingCallableDeclaration.into()),
-        expression("f(uint)")
-            .with_members(context)
-            .into_diagnostic(),
-    );
-}
-
-#[test]
 fn test_overloaded_call_operand_narrows_to_selected_overload() {
     // When an overloaded callee resolves to a single overload through the
     // call's arguments, the operand's typing is narrowed from the whole

--- a/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
+++ b/crates/solidity-v2/outputs/cargo/tests/src/diagnostics_output/snapshots.generated.rs
@@ -3874,6 +3874,14 @@ mod type_system {
         }
 
         #[test]
+        fn built_in_type_name_argument() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "built_in_type_name_argument",
+            )
+        }
+
+        #[test]
         fn call_argument() -> Result<()> {
             run("type_system/expression_not_a_value", "call_argument")
         }
@@ -3923,6 +3931,14 @@ mod type_system {
         }
 
         #[test]
+        fn function_declaration_built_in_argument() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "function_declaration_built_in_argument",
+            )
+        }
+
+        #[test]
         fn index_access_index() -> Result<()> {
             run("type_system/expression_not_a_value", "index_access_index")
         }
@@ -3932,6 +3948,14 @@ mod type_system {
             run(
                 "type_system/expression_not_a_value",
                 "inheritance_specifier_argument",
+            )
+        }
+
+        #[test]
+        fn library_name_conversion() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "library_name_conversion",
             )
         }
 
@@ -4047,6 +4071,46 @@ mod type_system {
         #[test]
         fn tuple_component() -> Result<()> {
             run("type_system/expression_not_a_value", "tuple_component")
+        }
+
+        #[test]
+        fn type_name_call_argument() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "type_name_call_argument",
+            )
+        }
+
+        #[test]
+        fn type_name_index_access_operand() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "type_name_index_access_operand",
+            )
+        }
+
+        #[test]
+        fn type_name_initializer() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "type_name_initializer",
+            )
+        }
+
+        #[test]
+        fn type_name_operator_operand() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "type_name_operator_operand",
+            )
+        }
+
+        #[test]
+        fn type_name_overloaded_call_argument() -> Result<()> {
+            run(
+                "type_system/expression_not_a_value",
+                "type_name_overloaded_call_argument",
+            )
         }
 
         #[test]

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_type_name_argument/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_type_name_argument/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_type_name_argument/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_type_name_argument/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_type_name_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/built_in_type_name_argument/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: a built-in takes a type name, since the second argument of
+// `abi.decode` is the tuple of types to decode into.
+
+contract Test {
+  function f(bytes memory data) public pure returns (uint256, bool) {
+    return abi.decode(data, (uint256, bool));
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/.tests.config.json
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/.tests.config.json
@@ -1,0 +1,15 @@
+{
+  "matrix": {
+    "type": "SingleTargetAllVersions",
+    "expected_solc_divergence": [
+      {
+        "specifier": {
+          "type": "Range",
+          "from": "0.8.11",
+          "till": "0.8.12"
+        },
+        "reason": "solc '0.8.11' rejects an external function reached through a contract type name as not being 'public' or 'external', which it stopped doing in '0.8.12'. Slang accepts it on every version that has `abi.encodeCall`."
+      }
+    ]
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[resolution/incompatible-built-in-version] Error: This built-in was introduced in version '0.8.11'.
+    ╭─[input.sol:13:20]
+    │
+ 13 │         return abi.encodeCall(C.g, (1));
+    │                    ─────┬────  
+    │                         ╰────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/slang/0.8.11-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/slang/0.8.11-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9582] Error: Member "encodeCall" not found or not visible after argument-dependent lookup in abi.
+    ╭─[input.sol:13:16]
+    │
+ 13 │         return abi.encodeCall(C.g, (1));
+    │                ───────┬──────  
+    │                       ╰──────── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/solc/0.8.11-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/solc/0.8.11-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 3509] Error: Function must be "public" or "external".
+    ╭─[input.sol:13:31]
+    │
+ 13 │         return abi.encodeCall(C.g, (1));
+    │                               ─┬─  
+    │                                ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/solc/0.8.12-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/generated/solc/0.8.12-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/function_declaration_built_in_argument/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: `abi.encodeCall` takes the function it encodes a call to, and one
+// reached through a contract type name is a declaration rather than a value.
+
+contract C {
+    function g(uint256 x) external {}
+}
+
+contract Test {
+    function f() public pure returns (bytes memory) {
+        return abi.encodeCall(C.g, (1));
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/library_name_conversion/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/library_name_conversion/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/library_name_conversion/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/library_name_conversion/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/library_name_conversion/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/library_name_conversion/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: a conversion takes a type name, since a library name converts to
+// the address the library is deployed at.
+
+library L {
+  function f() external {}
+}
+
+contract Test {
+  function f() public pure returns (address) {
+    return address(L);
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_call_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_call_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
+    ╭─[input.sol:13:10]
+    │
+ 13 │     take(E);
+    │          ┬  
+    │          ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_call_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_call_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9553] Error: Invalid type for argument in function call. Invalid implicit conversion from type(enum Test.E) to uint256 requested.
+    ╭─[input.sol:13:10]
+    │
+ 13 │     take(E);
+    │          ┬  
+    │          ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_call_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_call_argument/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: an argument of an ordinary call is a value position, and a
+// user-defined type name names a type.
+
+contract Test {
+  enum E { A }
+
+  function take(uint) internal pure {}
+
+  function f() public pure {
+    take(E);
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_index_access_operand/generated/slang/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_index_access_operand/generated/slang/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_index_access_operand/generated/solc/0.8.0-success.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_index_access_operand/generated/solc/0.8.0-success.txt
@@ -1,0 +1,3 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 0

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_index_access_operand/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_index_access_operand/input.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Accepted: the operand of an index access may name a type, since indexing a
+// type name names the array type of it — dynamic or fixed-size, elementary or
+// user-defined. Here each one is the target of an explicit conversion.
+
+contract Test {
+    struct Point {
+        uint256 x;
+    }
+
+    function f(uint256[] memory a, Point[2] memory b) public pure {
+        uint256[] memory c = uint256[](a);
+        Point[2] memory d = Point[2](b);
+        c;
+        d;
+    }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_initializer/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_initializer/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
+   ╭─[input.sol:9:17]
+   │
+ 9 │     uint256 x = uint;
+   │                 ──┬─  
+   │                   ╰─── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_initializer/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_initializer/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9574] Error: Type type(uint256) is not implicitly convertible to expected type uint256.
+   ╭─[input.sol:9:5]
+   │
+ 9 │     uint256 x = uint;
+   │     ────────┬───────  
+   │             ╰───────── Error occurred here.
+───╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_initializer/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_initializer/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: an initialiser is a value position, and an elementary type keyword
+// names a type.
+
+contract Test {
+  function f() public pure {
+    uint256 x = uint;
+    x;
+  }
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
+    ╭─[input.sol:10:12]
+    │
+ 10 │     return E + E;
+    │            ┬  
+    │            ╰── Error occurred here.
+────╯
+
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
+    ╭─[input.sol:10:16]
+    │
+ 10 │     return E + E;
+    │                ┬  
+    │                ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 2271] Error: Operator + not compatible with types type(enum E) and type(enum E)
+    ╭─[input.sol:10:12]
+    │
+ 10 │     return E + E;
+    │            ──┬──  
+    │              ╰──── Error occurred here.
+────╯
+
+[TypeError 6359] Error: Return argument type type(enum E) is not implicitly convertible to expected type (type of first return variable) uint256.
+    ╭─[input.sol:10:12]
+    │
+ 10 │     return E + E;
+    │            ──┬──  
+    │              ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/solc/0.8.16-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/solc/0.8.16-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 2271] Error: Operator + not compatible with types type(enum E) and type(enum E).
+    ╭─[input.sol:10:12]
+    │
+ 10 │     return E + E;
+    │            ──┬──  
+    │              ╰──── Error occurred here.
+────╯
+
+[TypeError 6359] Error: Return argument type type(enum E) is not implicitly convertible to expected type (type of first return variable) uint256.
+    ╭─[input.sol:10:12]
+    │
+ 10 │     return E + E;
+    │            ──┬──  
+    │              ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/solc/0.8.18-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/generated/solc/0.8.18-failure.txt
@@ -1,0 +1,19 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 2
+
+[TypeError 2271] Error: Built-in binary operator + cannot be applied to types type(enum E) and type(enum E).
+    ╭─[input.sol:10:12]
+    │
+ 10 │     return E + E;
+    │            ──┬──  
+    │              ╰──── Error occurred here.
+────╯
+
+[TypeError 6359] Error: Return argument type type(enum E) is not implicitly convertible to expected type (type of first return variable) uint256.
+    ╭─[input.sol:10:12]
+    │
+ 10 │     return E + E;
+    │            ──┬──  
+    │              ╰──── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_operator_operand/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported: both operands of an operator are value positions, so a type name
+// is reported in each of them rather than once for the expression.
+
+enum E { A }
+
+function add() pure returns (uint256) {
+    return E + E;
+}

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_overloaded_call_argument/generated/slang/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_overloaded_call_argument/generated/slang/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[type-system/expression-not-a-value] Error: This expression denoting a type or module cannot be used as a value.
+    ╭─[input.sol:16:7]
+    │
+ 16 │     f(uint);
+    │       ──┬─  
+    │         ╰─── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_overloaded_call_argument/generated/solc/0.8.0-failure.txt
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_overloaded_call_argument/generated/solc/0.8.0-failure.txt
@@ -1,0 +1,11 @@
+# This file is generated automatically by infrastructure scripts. Please don't edit by hand.
+
+Diagnostics: 1
+
+[TypeError 9322] Error: No matching declaration found after argument-dependent lookup.
+    ╭─[input.sol:16:5]
+    │
+ 16 │     f(uint);
+    │     ┬  
+    │     ╰── Error occurred here.
+────╯

--- a/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_overloaded_call_argument/input.sol
+++ b/crates/solidity-v2/testing/snapshots/diagnostics_output/type_system/expression_not_a_value/type_name_overloaded_call_argument/input.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity *;
+
+// Reported once: an argument that is not a value cannot select an overload, so
+// the call is left alone rather than reported as matching no candidate on top.
+
+function f(uint256 x) pure returns (bool) {
+    return x > 0;
+}
+
+function f(bool x) pure returns (uint256) {
+    return x ? 1 : 0;
+}
+
+function call() pure {
+    f(uint);
+}


### PR DESCRIPTION
Except some specific cases, when checking for a value type a meta type can be rejected. The exceptions are:
- positional arguments to built-in functions that accept metatypes, eg. `abi.decode`, `abi.encodeCall`
- `address` casts for libraries, ie. `address(L)`
- operands of index access expressions, as they can name array types
- tuple components, as they are used to declare the output types for `abi.decode`